### PR TITLE
feat: User API 3개 구현 (내 프로필 조회, 프로필 수정, 유저 프로필 조회)

### DIFF
--- a/src/main/java/com/instagram/backend/domain/auth/dto/LoginRequest.java
+++ b/src/main/java/com/instagram/backend/domain/auth/dto/LoginRequest.java
@@ -14,5 +14,5 @@ public class LoginRequest {
     private String email;
 
     @NotBlank(message = "비밀번호를 입력해주세요.")
-    private String memberPassword;
+    private String password;
 }

--- a/src/main/java/com/instagram/backend/domain/auth/dto/LoginResponse.java
+++ b/src/main/java/com/instagram/backend/domain/auth/dto/LoginResponse.java
@@ -16,7 +16,7 @@ public class LoginResponse {
     @Builder
     public static class MemberInfo {
         private Long memberId;
-        private String memberUsername;
-        private String memberImageUrl; // 추후 Member 엔티티에 필드 추가 시 연동
+        private String username;
+        private String imageUrl;
     }
 }

--- a/src/main/java/com/instagram/backend/domain/auth/dto/SignupRequest.java
+++ b/src/main/java/com/instagram/backend/domain/auth/dto/SignupRequest.java
@@ -19,12 +19,12 @@ public class SignupRequest {
 
     @NotBlank(message = "비밀번호를 입력해주세요.")
     @Size(min = 8, message = "비밀번호는 8자 이상이어야 합니다.")
-    private String memberPassword;
+    private String password;
 
     @NotBlank(message = "유저네임을 입력해주세요.")
     @Pattern(regexp = "^[a-zA-Z0-9_]+$", message = "유저네임은 영문, 숫자, _만 사용 가능합니다.")
-    private String memberUsername;
+    private String username;
 
     @NotBlank(message = "이름을 입력해주세요.")
-    private String memberName;
+    private String name;
 }

--- a/src/main/java/com/instagram/backend/domain/auth/dto/SignupResponse.java
+++ b/src/main/java/com/instagram/backend/domain/auth/dto/SignupResponse.java
@@ -8,5 +8,5 @@ import lombok.Getter;
 public class SignupResponse {
 
     private Long memberId;
-    private String memberUsername;
+    private String username;
 }

--- a/src/main/java/com/instagram/backend/domain/auth/service/AuthService.java
+++ b/src/main/java/com/instagram/backend/domain/auth/service/AuthService.java
@@ -29,21 +29,21 @@ public class AuthService {
         if (memberRepository.existsByEmail(request.getEmail())) {
             throw new BusinessException(ErrorCode.DUPLICATE_EMAIL);
         }
-        if (memberRepository.existsByMemberUsername(request.getMemberUsername())) {
+        if (memberRepository.existsByUsername(request.getUsername())) {
             throw new BusinessException(ErrorCode.DUPLICATE_USERNAME);
         }
 
         Member member = Member.builder()
                 .email(request.getEmail())
-                .memberPassword(passwordEncoder.encode(request.getMemberPassword()))
-                .memberUsername(request.getMemberUsername())
-                .memberName(request.getMemberName())
+                .password(passwordEncoder.encode(request.getPassword()))
+                .username(request.getUsername())
+                .name(request.getName())
                 .build();
         memberRepository.save(member);
 
         return SignupResponse.builder()
-                .memberId(member.getId())
-                .memberUsername(member.getMemberUsername())
+                .memberId(member.getMemberId())
+                .username(member.getUsername())
                 .build();
     }
 
@@ -51,17 +51,16 @@ public class AuthService {
         Member member = memberRepository.findByEmail(request.getEmail())
                 .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
 
-        if (!passwordEncoder.matches(request.getMemberPassword(), member.getMemberPassword())) {
+        if (!passwordEncoder.matches(request.getPassword(), member.getPassword())) {
             throw new BusinessException(ErrorCode.INVALID_CREDENTIALS);
         }
 
-        String accessToken = jwtTokenProvider.generateAccessToken(member.getId(), member.getRole());
-        String refreshToken = jwtTokenProvider.generateRefreshToken(member.getId());
+        String accessToken = jwtTokenProvider.generateAccessToken(member.getMemberId(), member.getRole());
+        String refreshToken = jwtTokenProvider.generateRefreshToken(member.getMemberId());
 
-        // 기존 Refresh Token 삭제 후 새로 저장 (중복 로그인 처리)
-        refreshTokenRepository.deleteByMemberId(member.getId());
+        refreshTokenRepository.deleteByMemberId(member.getMemberId());
         refreshTokenRepository.save(RefreshToken.builder()
-                .memberId(member.getId())
+                .memberId(member.getMemberId())
                 .token(refreshToken)
                 .expiresAt(LocalDateTime.now().plusSeconds(jwtTokenProvider.getRefreshExpiration() / 1000))
                 .build());
@@ -71,9 +70,9 @@ public class AuthService {
                 .refreshToken(refreshToken)
                 .expiresIn(jwtTokenProvider.getAccessExpiration() / 1000)
                 .member(LoginResponse.MemberInfo.builder()
-                        .memberId(member.getId())
-                        .memberUsername(member.getMemberUsername())
-                        .memberImageUrl(null) // 추후 Member 엔티티에 memberImageUrl 추가 시 연동
+                        .memberId(member.getMemberId())
+                        .username(member.getUsername())
+                        .imageUrl(member.getImageUrl())
                         .build())
                 .build();
     }

--- a/src/main/java/com/instagram/backend/domain/follow/entity/Follow.java
+++ b/src/main/java/com/instagram/backend/domain/follow/entity/Follow.java
@@ -1,1 +1,38 @@
 package com.instagram.backend.domain.follow.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/*
+  Follow 엔티티 — follows 테이블 매핑
+  팔로우 관계를 저장: "followerId가 followingId를 팔로우한다"
+
+  여기서는 Member 엔티티를 직접 참조(@ManyToOne)하지 않고 ID만 저장
+  → 단순한 관계 테이블에서는 이렇게 하면 불필요한 JOIN을 피할 수 있음
+  → 필요할 때만 MemberRepository로 조회하면 됨
+*/
+@Entity
+@Table(name = "follows")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Follow {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long followId;
+
+    @Column(nullable = false)
+    private Long followerId;
+
+    @Column(nullable = false)
+    private Long followingId;
+
+    @Builder
+    public Follow(Long followerId, Long followingId) {
+        this.followerId = followerId;
+        this.followingId = followingId;
+    }
+}

--- a/src/main/java/com/instagram/backend/domain/follow/repository/FollowRepository.java
+++ b/src/main/java/com/instagram/backend/domain/follow/repository/FollowRepository.java
@@ -1,1 +1,25 @@
 package com.instagram.backend.domain.follow.repository;
+
+import com.instagram.backend.domain.follow.entity.Follow;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/*
+  FollowRepository — follows 테이블에 접근하는 Repository
+
+  countBy~ 메서드 — Spring Data JPA가 자동으로 COUNT 쿼리 생성
+  existsBy~ 메서드 — 존재 여부를 boolean으로 반환 (COUNT보다 성능 좋음)
+*/
+public interface FollowRepository extends JpaRepository<Follow, Long> {
+
+    // SELECT COUNT(*) FROM follows WHERE following_id = ?
+    // → 특정 유저를 팔로우하는 사람 수 (팔로워 수)
+    long countByFollowingId(Long followingId);
+
+    // SELECT COUNT(*) FROM follows WHERE follower_id = ?
+    // → 특정 유저가 팔로우하는 사람 수 (팔로잉 수)
+    long countByFollowerId(Long followerId);
+
+    // SELECT EXISTS(SELECT 1 FROM follows WHERE follower_id = ? AND following_id = ?)
+    // → 내가(followerId) 상대(followingId)를 팔로우하고 있는지 확인
+    boolean existsByFollowerIdAndFollowingId(Long followerId, Long followingId);
+}

--- a/src/main/java/com/instagram/backend/domain/member/controller/MemberController.java
+++ b/src/main/java/com/instagram/backend/domain/member/controller/MemberController.java
@@ -1,1 +1,60 @@
 package com.instagram.backend.domain.member.controller;
+
+import com.instagram.backend.domain.member.dto.*;
+import com.instagram.backend.domain.member.service.MemberService;
+import com.instagram.backend.global.dto.ApiResponse;
+import com.instagram.backend.global.security.CustomUserDetails;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+/*
+  @RestController — @Controller + @ResponseBody
+    — 이 클래스의 모든 메서드가 JSON 응답을 반환함을 선언
+    — @Controller만 쓰면 HTML 뷰를 반환, @RestController는 JSON API용
+
+  @RequestMapping("/api/users")
+    — 이 컨트롤러의 모든 엔드포인트가 /api/users로 시작
+    — 메서드별 @GetMapping, @PatchMapping은 이 경로 뒤에 추가됨
+
+  @AuthenticationPrincipal CustomUserDetails userDetails
+    — JWT 필터가 토큰을 검증한 후 SecurityContext에 저장한 유저 정보를 꺼냄
+    — userDetails.getMemberId()로 현재 로그인한 유저의 ID를 얻을 수 있음
+
+  @Valid — Request Body의 Bean Validation 어노테이션(@Size 등)을 실행
+    — 검증 실패 시 MethodArgumentNotValidException → GlobalExceptionHandler가 처리
+*/
+@RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
+public class MemberController {
+
+    private final MemberService memberService;
+
+    // GET /api/users/me — 내 프로필 조회
+    @GetMapping("/me")
+    public ApiResponse<MyProfileResponse> getMyProfile(
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        MyProfileResponse response = memberService.getMyProfile(userDetails.getMemberId());
+        return ApiResponse.success(response, "프로필 조회에 성공하였습니다.");
+    }
+
+    // PATCH /api/users/me — 프로필 수정
+    @PatchMapping("/me")
+    public ApiResponse<ProfileUpdateResponse> updateProfile(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestBody ProfileUpdateRequest request) {
+        ProfileUpdateResponse response = memberService.updateProfile(userDetails.getMemberId(), request);
+        return ApiResponse.success(response, "프로필이 수정되었습니다.");
+    }
+
+    // GET /api/users/{username} — 다른 유저 프로필 조회
+    @GetMapping("/{username}")
+    public ApiResponse<UserProfileResponse> getUserProfile(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable String username) {
+        UserProfileResponse response = memberService.getUserProfile(userDetails.getMemberId(), username);
+        return ApiResponse.success(response, "프로필 조회에 성공하였습니다.");
+    }
+}

--- a/src/main/java/com/instagram/backend/domain/member/dto/MyProfileResponse.java
+++ b/src/main/java/com/instagram/backend/domain/member/dto/MyProfileResponse.java
@@ -1,1 +1,56 @@
 package com.instagram.backend.domain.member.dto;
+
+import com.instagram.backend.domain.member.entity.Gender;
+import com.instagram.backend.domain.member.entity.Member;
+import lombok.Builder;
+import lombok.Getter;
+
+/*
+  DTO (Data Transfer Object) — 클라이언트에 보낼 데이터만 담는 객체
+
+  왜 Entity를 직접 반환하지 않는가?
+  1. Entity에는 password, isDeleted 같은 내부 필드가 있음 → 노출되면 안 됨
+  2. API마다 필요한 필드가 다름 → 내 프로필은 phone 포함, 다른 유저 프로필은 제외
+  3. Entity가 바뀌어도 API 응답은 안 바뀌게 분리 → 유지보수 편함
+
+  from() 정적 메서드 — Entity를 DTO로 변환하는 팩토리 메서드
+  변환 로직을 DTO 안에 두면, Service 레이어가 깔끔해짐
+*/
+@Getter
+@Builder
+public class MyProfileResponse {
+
+    private Long memberId;
+    private String username;
+    private String name;
+    private String bio;
+    private String phone;
+    private Gender gender;
+    private String imageUrl;
+    private String imageType;
+    private String imageName;
+    private String imageUuid;
+    private String role;
+    private Long postCount;
+    private Long followerCount;
+    private Long followingCount;
+
+    public static MyProfileResponse from(Member member, long postCount) {
+        return MyProfileResponse.builder()
+                .memberId(member.getMemberId())
+                .username(member.getUsername())
+                .name(member.getName())
+                .bio(member.getBio())
+                .phone(member.getPhone())
+                .gender(member.getGender())
+                .imageUrl(member.getImageUrl())
+                .imageType(member.getImageType())
+                .imageName(member.getImageName())
+                .imageUuid(member.getImageUuid())
+                .role(member.getRole())
+                .postCount(postCount)
+                .followerCount(member.getFollowerCount())
+                .followingCount(member.getFollowingCount())
+                .build();
+    }
+}

--- a/src/main/java/com/instagram/backend/domain/member/dto/ProfileUpdateRequest.java
+++ b/src/main/java/com/instagram/backend/domain/member/dto/ProfileUpdateRequest.java
@@ -1,1 +1,32 @@
 package com.instagram.backend.domain.member.dto;
+
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/*
+  요청 DTO — 클라이언트가 보낸 JSON을 Java 객체로 변환
+
+  @Size(max = 160) — Bean Validation 어노테이션
+  Spring이 자동으로 검증하고, 초과 시 MethodArgumentNotValidException 발생
+  → GlobalExceptionHandler가 잡아서 에러 응답으로 변환
+
+  @Getter — Jackson(JSON 라이브러리)이 역직렬화할 때 getter가 필요
+  @NoArgsConstructor — Jackson이 JSON → 객체 변환 시 기본 생성자가 필요
+*/
+@Getter
+@NoArgsConstructor
+public class ProfileUpdateRequest {
+
+    @Size(max = 50, message = "이름은 50자 이내로 입력해주세요.")
+    private String name;
+
+    @Size(max = 160, message = "소개글은 160자 이내로 입력해주세요.")
+    private String bio;
+
+    @Size(max = 20, message = "전화번호는 20자 이내로 입력해주세요.")
+    private String phone;
+
+    // gender는 String으로 받아서 Service에서 Enum 변환 + 검증
+    private String gender;
+}

--- a/src/main/java/com/instagram/backend/domain/member/dto/ProfileUpdateResponse.java
+++ b/src/main/java/com/instagram/backend/domain/member/dto/ProfileUpdateResponse.java
@@ -1,0 +1,28 @@
+package com.instagram.backend.domain.member.dto;
+
+import com.instagram.backend.domain.member.entity.Member;
+import lombok.Builder;
+import lombok.Getter;
+
+/*
+  프로필 수정 응답 DTO
+  API 명세에 따라 수정된 주요 필드만 반환
+*/
+@Getter
+@Builder
+public class ProfileUpdateResponse {
+
+    private Long memberId;
+    private String username;
+    private String name;
+    private String bio;
+
+    public static ProfileUpdateResponse from(Member member) {
+        return ProfileUpdateResponse.builder()
+                .memberId(member.getMemberId())
+                .username(member.getUsername())
+                .name(member.getName())
+                .bio(member.getBio())
+                .build();
+    }
+}

--- a/src/main/java/com/instagram/backend/domain/member/dto/UserProfileResponse.java
+++ b/src/main/java/com/instagram/backend/domain/member/dto/UserProfileResponse.java
@@ -1,1 +1,46 @@
 package com.instagram.backend.domain.member.dto;
+
+import com.instagram.backend.domain.member.entity.Member;
+import lombok.Builder;
+import lombok.Getter;
+
+/*
+  다른 유저 프로필 조회용 DTO
+  MyProfileResponse와 비교:
+  — phone, gender 제외 (타인의 개인정보)
+  — isFollowing 추가 (내가 이 유저를 팔로우하고 있는지)
+*/
+@Getter
+@Builder
+public class UserProfileResponse {
+
+    private Long memberId;
+    private String username;
+    private String name;
+    private String bio;
+    private String imageUrl;
+    private String imageType;
+    private String imageName;
+    private String imageUuid;
+    private Long postCount;
+    private Long followerCount;
+    private Long followingCount;
+    private Boolean isFollowing;
+
+    public static UserProfileResponse from(Member member, long postCount, boolean isFollowing) {
+        return UserProfileResponse.builder()
+                .memberId(member.getMemberId())
+                .username(member.getUsername())
+                .name(member.getName())
+                .bio(member.getBio())
+                .imageUrl(member.getImageUrl())
+                .imageType(member.getImageType())
+                .imageName(member.getImageName())
+                .imageUuid(member.getImageUuid())
+                .postCount(postCount)
+                .followerCount(member.getFollowerCount())
+                .followingCount(member.getFollowingCount())
+                .isFollowing(isFollowing)
+                .build();
+    }
+}

--- a/src/main/java/com/instagram/backend/domain/member/entity/Gender.java
+++ b/src/main/java/com/instagram/backend/domain/member/entity/Gender.java
@@ -1,0 +1,13 @@
+package com.instagram.backend.domain.member.entity;
+
+/*
+  Java Enum — 고정된 상수 값의 집합
+  DB에서 gender 컬럼이 ENUM 타입이므로, Java에서도 Enum으로 정의
+  M(남성), F(여성), N(선택안함) 3가지 값만 허용
+
+  문자열 "M"이 들어오면 Gender.valueOf("M")으로 변환 가능
+  잘못된 값이 오면 IllegalArgumentException 발생 → 이걸 잡아서 에러 응답
+*/
+public enum Gender {
+    M, F, N
+}

--- a/src/main/java/com/instagram/backend/domain/member/entity/Member.java
+++ b/src/main/java/com/instagram/backend/domain/member/entity/Member.java
@@ -7,39 +7,134 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
+/*
+  @Entity — 이 클래스가 DB 테이블과 매핑되는 JPA 엔티티임을 선언
+  @Table(name = "members") — 실제 DB 테이블 이름 지정 (클래스명과 다를 때 사용)
+  @Getter — 모든 필드의 getter 자동 생성 (Lombok)
+  @NoArgsConstructor(access = PROTECTED)
+    — 파라미터 없는 기본 생성자를 protected로 생성
+    — JPA는 내부적으로 기본 생성자가 필요하지만, 외부에서 new Member()로 생성하는 것은 막음
+    — 객체 생성은 Builder를 통해서만 하도록 유도
+*/
 @Entity
-@Table(name = "member")
+@Table(name = "members")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member extends BaseTimeEntity {
 
+    /*
+      @Id — 이 필드가 PK(Primary Key)임을 선언
+      @GeneratedValue(IDENTITY) — DB의 AUTO_INCREMENT를 사용해서 자동 증가
+    */
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    private Long memberId;
+
+    /*
+      @Column — DB 컬럼과 매핑 설정
+      nullable = false → NOT NULL 제약조건
+      unique = true → UNIQUE 제약조건
+      length = 30 → VARCHAR(30) 같은 길이 제한
+    */
+    @Column(nullable = false, unique = true)
+    private Long userId;
+
+    @Column(nullable = false, unique = true, length = 30)
+    private String username;
 
     @Column(nullable = false, unique = true)
     private String email;
 
-    @Column(name = "member_password", nullable = false)
-    private String memberPassword;
-
-    @Column(name = "member_username", nullable = false, unique = true)
-    private String memberUsername;
-
-    @Column(name = "member_name", nullable = false)
-    private String memberName;
-
-    // 팀원이 필드를 자유롭게 추가하세요 (bio, memberImageUrl 등)
-
     @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false, length = 50)
+    private String name;
+
+    @Column(nullable = false, length = 10)
     private String role;
 
+    @Column(length = 500)
+    private String bio;
+
+    @Column(length = 20)
+    private String phone;
+
+    /*
+      @Enumerated(STRING) — Enum 값을 DB에 문자열로 저장
+      EnumType.ORDINAL이면 숫자(0, 1, 2)로 저장되는데, 순서가 바뀌면 데이터가 꼬이므로
+      실무에서는 항상 STRING을 사용
+    */
+    @Enumerated(EnumType.STRING)
+    private Gender gender;
+
+    @Column(length = 500)
+    private String imageUrl;
+
+    @Column(length = 50)
+    private String imageType;
+
+    @Column(length = 255)
+    private String imageName;
+
+    @Column(length = 36)
+    private String imageUuid;
+
+    /*
+      soft delete — 실제 DB에서 행을 삭제하지 않고, is_deleted 플래그로 삭제 여부를 표시
+      실무에서 많이 쓰는 패턴: 데이터 복구가 가능하고, 연관 데이터가 깨지지 않음
+    */
+    @Column(nullable = false)
+    private Boolean isDeleted = false;
+
+    private LocalDateTime deletedAt;
+
+    /*
+      반정규화(Denormalization) 필드
+      — 팔로워/팔로잉 수를 매번 follows 테이블에서 COUNT 하면 느리므로
+      — members 테이블에 미리 저장해두고, 팔로우/언팔로우 시 +1/-1 업데이트
+      — 조회 성능을 위해 약간의 데이터 중복을 허용하는 전략
+    */
+    private Long followerCount = 0L;
+
+    private Long followingCount = 0L;
+
+    /*
+      @Builder — 빌더 패턴으로 객체 생성
+      Member.builder().username("john").name("John").build() 형태로 사용
+      생성자에 필요한 필드만 나열해서, 어떤 값이 필수인지 명확하게 표현
+    */
     @Builder
-    public Member(String email, String memberPassword, String memberUsername, String memberName) {
+    public Member(Long userId, String username, String email, String password, String name) {
+        this.userId = userId;
+        this.username = username;
         this.email = email;
-        this.memberPassword = memberPassword;
-        this.memberUsername = memberUsername;
-        this.memberName = memberName;
+        this.password = password;
+        this.name = name;
         this.role = "ROLE_USER";
+        this.isDeleted = false;
+        this.followerCount = 0L;
+        this.followingCount = 0L;
+    }
+
+    /*
+      도메인 메서드 — Entity가 자신의 상태를 변경하는 비즈니스 메서드
+      setter를 public으로 열지 않고, 의미 있는 이름의 메서드를 통해서만 변경 가능
+      → 어디서 어떤 이유로 값이 바뀌는지 추적하기 쉬움
+    */
+    public void updateProfile(String name, String bio, String phone, Gender gender) {
+        if (name != null) this.name = name;
+        if (bio != null) this.bio = bio;
+        if (phone != null) this.phone = phone;
+        if (gender != null) this.gender = gender;
+    }
+
+    public void updateProfileImage(String imageUrl, String imageType, String imageName, String imageUuid) {
+        this.imageUrl = imageUrl;
+        this.imageType = imageType;
+        this.imageName = imageName;
+        this.imageUuid = imageUuid;
     }
 }

--- a/src/main/java/com/instagram/backend/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/instagram/backend/domain/member/repository/MemberRepository.java
@@ -1,15 +1,32 @@
 package com.instagram.backend.domain.member.repository;
-    
+
 import com.instagram.backend.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
+/*
+  JpaRepository<Member, Long>
+  — Member 엔티티를 다루는 Repository (DB 접근 계층)
+  — Long은 PK(memberId)의 타입
+  — 기본 CRUD 메서드를 자동으로 제공: save(), findById(), findAll(), delete() 등
+
+  Spring Data JPA의 메서드 이름 규칙:
+  — findBy + 필드명 → 해당 필드로 조회하는 SQL을 자동 생성
+  — existsBy + 필드명 → 존재 여부 확인 (boolean 반환)
+  — Optional<Member> → 결과가 없을 수 있으므로 null 대신 Optional로 감싸서 반환
+*/
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
+    // SELECT * FROM members WHERE email = ? → 결과 없으면 Optional.empty()
     Optional<Member> findByEmail(String email);
 
+    // SELECT * FROM members WHERE username = ? AND is_deleted = false
+    Optional<Member> findByUsernameAndIsDeletedFalse(String username);
+
+    // SELECT EXISTS(SELECT 1 FROM members WHERE email = ?)
     boolean existsByEmail(String email);
 
-    boolean existsByMemberUsername(String memberUsername);
+    // SELECT EXISTS(SELECT 1 FROM members WHERE username = ?)
+    boolean existsByUsername(String username);
 }

--- a/src/main/java/com/instagram/backend/domain/member/service/MemberService.java
+++ b/src/main/java/com/instagram/backend/domain/member/service/MemberService.java
@@ -1,1 +1,103 @@
 package com.instagram.backend.domain.member.service;
+
+import com.instagram.backend.domain.follow.repository.FollowRepository;
+import com.instagram.backend.domain.member.dto.*;
+import com.instagram.backend.domain.member.entity.Gender;
+import com.instagram.backend.domain.member.entity.Member;
+import com.instagram.backend.domain.member.repository.MemberRepository;
+import com.instagram.backend.global.exception.BusinessException;
+import com.instagram.backend.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/*
+  @Service — 이 클래스가 비즈니스 로직을 담당하는 서비스 계층임을 선언
+             Spring이 자동으로 빈(Bean)으로 등록해서 의존성 주입(DI)에 사용
+
+  @Transactional(readOnly = true)
+    — 클래스 레벨에 선언하면 모든 메서드에 읽기 전용 트랜잭션 적용
+    — 읽기 전용이면 JPA가 변경 감지(dirty checking)를 안 하므로 성능 향상
+    — 데이터를 변경하는 메서드에는 @Transactional을 따로 붙여서 읽기 전용을 해제
+
+  @RequiredArgsConstructor
+    — final 필드를 파라미터로 받는 생성자를 자동 생성 (Lombok)
+    — Spring이 이 생성자를 보고 자동으로 의존성 주입 (생성자 주입 방식)
+*/
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+    private final FollowRepository followRepository;
+
+    /*
+      내 프로필 조회
+      — JWT에서 추출한 memberId로 Member 조회
+      — postCount는 아직 Post 엔티티가 없으므로 0으로 반환 (TODO: Post 개발 후 연동)
+    */
+    public MyProfileResponse getMyProfile(Long memberId) {
+        Member member = findMemberById(memberId);
+        long postCount = 0; // TODO: postRepository.countByMemberIdAndIsDeletedFalse(memberId)
+        return MyProfileResponse.from(member, postCount);
+    }
+
+    /*
+      프로필 수정
+      — @Transactional: 데이터를 변경하므로 읽기 전용 해제
+      — JPA의 변경 감지(dirty checking):
+        Entity 객체의 필드를 바꾸면, 트랜잭션이 끝날 때 JPA가 자동으로 UPDATE SQL 실행
+        별도로 save()를 호출할 필요가 없음
+    */
+    @Transactional
+    public ProfileUpdateResponse updateProfile(Long memberId, ProfileUpdateRequest request) {
+        Member member = findMemberById(memberId);
+
+        // gender 문자열 → Enum 변환 + 검증
+        Gender gender = parseGender(request.getGender());
+
+        // Entity의 도메인 메서드로 값 변경 → 트랜잭션 끝나면 자동 UPDATE
+        member.updateProfile(request.getName(), request.getBio(), request.getPhone(), gender);
+
+        return ProfileUpdateResponse.from(member);
+    }
+
+    /*
+      다른 유저 프로필 조회
+      — username으로 조회 + 삭제되지 않은 유저만
+      — 내가 이 유저를 팔로우하고 있는지 확인
+    */
+    public UserProfileResponse getUserProfile(Long myMemberId, String username) {
+        Member member = memberRepository.findByUsernameAndIsDeletedFalse(username)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+
+        long postCount = 0; // TODO: postRepository.countByMemberIdAndIsDeletedFalse(member.getMemberId())
+        boolean isFollowing = followRepository.existsByFollowerIdAndFollowingId(myMemberId, member.getMemberId());
+
+        return UserProfileResponse.from(member, postCount, isFollowing);
+    }
+
+    /*
+      private 헬퍼 메서드 — 반복되는 Member 조회 로직을 추출
+      찾지 못하면 MEMBER_NOT_FOUND 에러를 던짐
+    */
+    private Member findMemberById(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+    }
+
+    /*
+      gender 문자열을 Enum으로 변환
+      null이면 null 반환 (선택 필드이므로)
+      잘못된 값이면 INVALID_GENDER_VALUE 에러
+    */
+    private Gender parseGender(String gender) {
+        if (gender == null) return null;
+        try {
+            return Gender.valueOf(gender.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new BusinessException(ErrorCode.INVALID_GENDER_VALUE);
+        }
+    }
+}

--- a/src/main/java/com/instagram/backend/global/config/DataInitializer.java
+++ b/src/main/java/com/instagram/backend/global/config/DataInitializer.java
@@ -20,10 +20,11 @@ public class DataInitializer implements CommandLineRunner {
     public void run(String... args) {
         if (!memberRepository.existsByEmail("root@instagram.com")) {
             memberRepository.save(Member.builder()
+                    .userId(1L)
                     .email("root@instagram.com")
-                    .memberPassword(passwordEncoder.encode("root1234"))
-                    .memberUsername("root")
-                    .memberName("Root")
+                    .password(passwordEncoder.encode("root1234"))
+                    .username("root")
+                    .name("Root")
                     .build());
             System.out.println("[DataInitializer] Root 계정 생성 완료: root@instagram.com / root1234");
         }

--- a/src/main/java/com/instagram/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/instagram/backend/global/exception/ErrorCode.java
@@ -12,6 +12,9 @@ public enum ErrorCode {
     INVALID_PASSWORD_FORMAT(400, "비밀번호는 8자 이상이어야 합니다."),
     INVALID_USERNAME_FORMAT(400, "유저네임은 영문, 숫자, _만 사용 가능합니다."),
     MISSING_REQUIRED_FIELD(400, "필수 항목을 모두 입력해주세요."),
+    INVALID_BIO_LENGTH(400, "소개글은 160자 이내로 입력해주세요."),
+    INVALID_GENDER_VALUE(400, "성별 값이 올바르지 않습니다. (M/F/N)"),
+    INVALID_IMAGE_TYPE(400, "지원하지 않는 이미지 형식입니다."),
 
     // 401 - 인증 오류
     UNAUTHORIZED(401, "로그인이 필요합니다."),

--- a/src/main/java/com/instagram/backend/global/security/CustomUserDetailsService.java
+++ b/src/main/java/com/instagram/backend/global/security/CustomUserDetailsService.java
@@ -20,9 +20,9 @@ public class CustomUserDetailsService implements UserDetailsService {
                 .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다: " + email));
 
         return new CustomUserDetails(
-                member.getId(),
+                member.getMemberId(),
                 member.getEmail(),
-                member.getMemberPassword(),
+                member.getPassword(),
                 member.getRole()
         );
     }


### PR DESCRIPTION
  - Member Entity 확장: bio, phone, gender, image, follower/following count 등
  - Gender Enum, Follow Entity/Repository 생성
  - MemberService, MemberController, DTO 4개 구현
  - ErrorCode에 User 관련 에러 추가 (INVALID_BIO_LENGTH, INVALID_GENDER_VALUE 등)
  - Auth 코드 필드명 DB 컬럼명과 통일 (memberUsername → username 등)

  closes #6