### PR TITLE
feat: 팔로우/언팔로우 API 구현 (POST, DELETE /api/users/{memberId}/follow)

### DIFF
--- a/src/main/java/com/instagram/backend/domain/follow/controller/FollowController.java
+++ b/src/main/java/com/instagram/backend/domain/follow/controller/FollowController.java
@@ -1,0 +1,63 @@
+package com.instagram.backend.domain.follow.controller;
+
+import com.instagram.backend.domain.follow.service.FollowService;
+import com.instagram.backend.global.dto.ApiResponse;
+import com.instagram.backend.global.security.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+/*
+  FollowController — 팔로우/언팔로우 API
+
+  @RequestMapping("/api/users")
+    — MemberController와 같은 base path를 사용
+    — Spring은 같은 path를 여러 Controller가 나눠 쓸 수 있음
+    — 중요한 건 "메서드 + 전체 경로"의 조합이 겹치지 않으면 됨
+      예: MemberController의 GET /me와 FollowController의 POST /{memberId}/follow는 겹치지 않음
+
+  @PathVariable Long memberId
+    — URL 경로의 {memberId} 값을 파라미터로 받음
+    — 예: POST /api/users/5/follow → memberId = 5
+    — 팔로우 대상의 member_id를 URL에 포함시키는 것은 RESTful API 설계 원칙
+      (리소스를 URL로 표현: "5번 유저를 팔로우한다")
+*/
+@RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
+public class FollowController {
+
+    private final FollowService followService;
+
+    /*
+      POST /api/users/{memberId}/follow — 팔로우
+
+      왜 Request Body가 없나?
+        — 팔로우에 필요한 정보는 딱 두 가지: 나(JWT), 상대(URL의 memberId)
+        — 둘 다 이미 있으므로 Body가 필요 없음
+        — GET/DELETE처럼 Body 없이 동작하는 POST도 있음
+    */
+    @PostMapping("/{memberId}/follow")
+    public ApiResponse<Void> follow(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long memberId) {
+        followService.follow(userDetails.getMemberId(), memberId);
+        return ApiResponse.success(null, "팔로우에 성공하였습니다.");
+    }
+
+    /*
+      DELETE /api/users/{memberId}/follow — 언팔로우
+
+      왜 DELETE 메서드를 사용하나?
+        — REST 원칙: 리소스를 삭제할 때 DELETE 사용
+        — "팔로우 관계"라는 리소스를 삭제하는 행위이므로 DELETE가 적절
+        — POST로 언팔로우를 만들어도 동작은 하지만, REST 규약에 맞지 않음
+    */
+    @DeleteMapping("/{memberId}/follow")
+    public ApiResponse<Void> unfollow(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long memberId) {
+        followService.unfollow(userDetails.getMemberId(), memberId);
+        return ApiResponse.success(null, "언팔로우에 성공하였습니다.");
+    }
+}

--- a/src/main/java/com/instagram/backend/domain/follow/repository/FollowRepository.java
+++ b/src/main/java/com/instagram/backend/domain/follow/repository/FollowRepository.java
@@ -22,4 +22,8 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
     // SELECT EXISTS(SELECT 1 FROM follows WHERE follower_id = ? AND following_id = ?)
     // → 내가(followerId) 상대(followingId)를 팔로우하고 있는지 확인
     boolean existsByFollowerIdAndFollowingId(Long followerId, Long followingId);
+
+    // 팔로우 관계를 조회 — 언팔로우 시 삭제할 Follow 엔티티를 찾기 위해 사용
+    // Optional: 관계가 없을 수도 있으므로 null-safe 처리
+    java.util.Optional<Follow> findByFollowerIdAndFollowingId(Long followerId, Long followingId);
 }

--- a/src/main/java/com/instagram/backend/domain/follow/service/FollowService.java
+++ b/src/main/java/com/instagram/backend/domain/follow/service/FollowService.java
@@ -1,0 +1,114 @@
+package com.instagram.backend.domain.follow.service;
+
+import com.instagram.backend.domain.follow.entity.Follow;
+import com.instagram.backend.domain.follow.repository.FollowRepository;
+import com.instagram.backend.domain.member.entity.Member;
+import com.instagram.backend.domain.member.repository.MemberRepository;
+import com.instagram.backend.global.exception.BusinessException;
+import com.instagram.backend.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/*
+  FollowService — 팔로우/언팔로우 비즈니스 로직
+
+  왜 MemberService가 아니라 별도 Service로 분리했나?
+    — 팔로우는 "두 유저 간의 관계"를 다루는 로직
+    — MemberService는 "한 유저의 프로필"을 다루는 로직
+    — 관심사가 다르므로 분리하면 각 Service가 작아지고 유지보수가 쉬움
+    — 실무에서도 도메인별로 Service를 나누는 것이 일반적
+
+  @Transactional(readOnly = true)
+    — 클래스 레벨: 기본적으로 읽기 전용 (조회 성능 최적화)
+    — 데이터를 변경하는 메서드에만 @Transactional을 따로 붙임
+*/
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class FollowService {
+
+    private final FollowRepository followRepository;
+    private final MemberRepository memberRepository;
+
+    /*
+      팔로우
+      — 검증 순서: 자기자신 팔로우 방지 → 대상 존재 확인 → 중복 팔로우 확인
+      — 검증을 먼저 하는 이유: DB에 잘못된 데이터가 들어가는 것을 방지 (방어적 프로그래밍)
+
+      Follow 엔티티 저장 + 양쪽 Member의 카운트 증감
+        — 나(follower)의 followingCount +1
+        — 상대(following)의 followerCount +1
+        — 이렇게 카운트를 직접 관리하면 프로필 조회 시 COUNT 쿼리가 필요 없음
+
+      왜 findMemberById를 두 번 호출하나?
+        — 나(me)와 상대(target) 둘 다 Member 엔티티가 필요
+        — 나: followingCount를 올리기 위해
+        — 상대: followerCount를 올리기 위해 + 존재 확인
+    */
+    @Transactional
+    public void follow(Long myMemberId, Long targetMemberId) {
+        // 1. 자기 자신을 팔로우하는지 검증
+        if (myMemberId.equals(targetMemberId)) {
+            throw new BusinessException(ErrorCode.CANNOT_FOLLOW_SELF);
+        }
+
+        // 2. 팔로우 대상이 존재하는지 확인
+        Member target = findMemberById(targetMemberId);
+        Member me = findMemberById(myMemberId);
+
+        // 3. 이미 팔로우했는지 확인 (중복 방지)
+        if (followRepository.existsByFollowerIdAndFollowingId(myMemberId, targetMemberId)) {
+            throw new BusinessException(ErrorCode.ALREADY_FOLLOWING);
+        }
+
+        // 4. Follow 관계 저장
+        Follow follow = Follow.builder()
+                .followerId(myMemberId)
+                .followingId(targetMemberId)
+                .build();
+        followRepository.save(follow);
+
+        // 5. 양쪽 카운트 업데이트 (dirty checking으로 자동 UPDATE)
+        me.incrementFollowingCount();
+        target.incrementFollowerCount();
+    }
+
+    /*
+      언팔로우
+      — 팔로우 관계가 없으면 FOLLOW_NOT_FOUND 에러
+      — Follow 엔티티 삭제 + 양쪽 카운트 감소
+
+      delete() vs deleteById()
+        — delete(entity): 엔티티 객체를 넘겨서 삭제
+        — deleteById(id): ID만으로 삭제
+        — 여기서는 이미 조회한 follow 객체가 있으므로 delete() 사용
+    */
+    @Transactional
+    public void unfollow(Long myMemberId, Long targetMemberId) {
+        // 1. 팔로우 대상이 존재하는지 확인
+        Member target = findMemberById(targetMemberId);
+        Member me = findMemberById(myMemberId);
+
+        // 2. 팔로우 관계 조회 (없으면 에러)
+        Follow follow = followRepository.findByFollowerIdAndFollowingId(myMemberId, targetMemberId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.FOLLOW_NOT_FOUND));
+
+        // 3. Follow 관계 삭제
+        followRepository.delete(follow);
+
+        // 4. 양쪽 카운트 감소
+        me.decrementFollowingCount();
+        target.decrementFollowerCount();
+    }
+
+    /*
+      private 헬퍼 — Member 조회
+      MemberService에도 같은 메서드가 있지만, Service 간 직접 호출을 피하기 위해 각자 가짐
+      → Service끼리 의존하면 순환 참조 위험이 있고, 각 Service가 독립적으로 동작하는 것이 좋음
+    */
+    private Member findMemberById(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/instagram/backend/domain/member/entity/Member.java
+++ b/src/main/java/com/instagram/backend/domain/member/entity/Member.java
@@ -93,4 +93,15 @@ public class Member extends BaseSoftDeleteEntity {
         this.imageName = imageName;
         this.imageUuid = imageUuid;
     }
+
+    /*
+      팔로워/팔로잉 카운트 증감 메서드
+      — 팔로우/언팔로우 시 실시간으로 카운트를 변경
+      — 매번 COUNT 쿼리를 날리지 않고 숫자만 +1/-1 하므로 성능이 좋음 (비정규화)
+      — 0 미만으로 내려가지 않도록 방어 코드 추가
+    */
+    public void incrementFollowerCount() { this.followerCount++; }
+    public void decrementFollowerCount() { if (this.followerCount > 0) this.followerCount--; }
+    public void incrementFollowingCount() { this.followingCount++; }
+    public void decrementFollowingCount() { if (this.followingCount > 0) this.followingCount--; }
 }

--- a/src/main/java/com/instagram/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/instagram/backend/global/exception/ErrorCode.java
@@ -30,18 +30,21 @@ public enum ErrorCode {
     AUTH_ACCESS_DENIED(403, "접근 권한이 없습니다."),
     FORBIDDEN(403, "본인의 게시물만 수정/삭제할 수 있습니다."),
 
+    CANNOT_FOLLOW_SELF(400, "자기 자신을 팔로우할 수 없습니다."),
+
     // 404 - 리소스 없음
     MEMBER_NOT_FOUND(404, "존재하지 않는 계정입니다."),
     POST_NOT_FOUND(404, "존재하지 않는 게시물입니다."),
     LIKE_NOT_FOUND(404, "좋아요 내역이 존재하지 않습니다."),
     BOOKMARK_NOT_FOUND(404, "저장 내역이 존재하지 않습니다."),
-
+    FOLLOW_NOT_FOUND(404, "팔로우 관계가 존재하지 않습니다."),
 
     // 409 - 중복
     DUPLICATE_EMAIL(409, "이미 사용 중인 이메일입니다."),
     DUPLICATE_USERNAME(409, "이미 사용 중인 유저네임입니다."),
     ALREADY_LIKED(409, "이미 좋아요한 게시물입니다."),
     ALREADY_BOOKMARKED(409, "이미 저장한 게시물입니다."),
+    ALREADY_FOLLOWING(409, "이미 팔로우한 사용자입니다."),
 
     // 500 - 서버 오류
     INTERNAL_SERVER_ERROR(500, "서버 오류가 발생했습니다.");


### PR DESCRIPTION
  - FollowService/Controller 생성 (팔로우, 언팔로우 로직)
  - 검증: 자기자신 팔로우 방지, 중복 팔로우 방지, 팔로우 관계 미존재 처리
  - Member 엔티티에 followerCount/followingCount 증감 메서드 추가
  - ErrorCode 추가 (CANNOT_FOLLOW_SELF, ALREADY_FOLLOWING, FOLLOW_NOT_FOUND)

  closes #21