### PR TITLE
feat: 팔로워/팔로잉 목록 조회 API 구현 (GET/api/users/{username}/followers, following)

### DIFF
--- a/src/main/java/com/instagram/backend/domain/follow/controller/FollowController.java
+++ b/src/main/java/com/instagram/backend/domain/follow/controller/FollowController.java
@@ -1,7 +1,9 @@
 package com.instagram.backend.domain.follow.controller;
 
+import com.instagram.backend.domain.follow.dto.FollowListResponse;
 import com.instagram.backend.domain.follow.service.FollowService;
 import com.instagram.backend.global.dto.ApiResponse;
+import com.instagram.backend.global.dto.CursorPageResponse;
 import com.instagram.backend.global.security.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -59,5 +61,44 @@ public class FollowController {
             @PathVariable Long memberId) {
         followService.unfollow(userDetails.getMemberId(), memberId);
         return ApiResponse.success(null, "언팔로우에 성공하였습니다.");
+    }
+
+    /*
+      GET /api/users/{username}/followers — 팔로워 목록 조회
+
+      @RequestParam — URL의 쿼리 파라미터를 받음
+        — 예: GET /api/users/john/followers?cursor=100&limit=20
+        — required = false: 첫 페이지에서는 cursor가 없으므로 선택적
+        — defaultValue = "20": limit을 안 보내면 기본 20개
+
+      @PathVariable vs @RequestParam 차이:
+        — @PathVariable: URL 경로의 일부 (/users/{username}/followers → username)
+        — @RequestParam: URL 뒤의 ?key=value (cursor, limit)
+        — 리소스 식별 = PathVariable, 옵션/필터 = RequestParam
+    */
+    @GetMapping("/{username}/followers")
+    public ApiResponse<CursorPageResponse<FollowListResponse>> getFollowers(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable String username,
+            @RequestParam(required = false) String cursor,
+            @RequestParam(defaultValue = "20") int limit) {
+        CursorPageResponse<FollowListResponse> response =
+                followService.getFollowers(userDetails.getMemberId(), username, cursor, limit);
+        return ApiResponse.success(response, "팔로워 목록 조회에 성공하였습니다.");
+    }
+
+    /*
+      GET /api/users/{username}/following — 팔로잉 목록 조회
+      — 팔로워 목록과 동일한 구조, 데이터 방향만 다름
+    */
+    @GetMapping("/{username}/following")
+    public ApiResponse<CursorPageResponse<FollowListResponse>> getFollowing(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable String username,
+            @RequestParam(required = false) String cursor,
+            @RequestParam(defaultValue = "20") int limit) {
+        CursorPageResponse<FollowListResponse> response =
+                followService.getFollowing(userDetails.getMemberId(), username, cursor, limit);
+        return ApiResponse.success(response, "팔로잉 목록 조회에 성공하였습니다.");
     }
 }

--- a/src/main/java/com/instagram/backend/domain/follow/dto/FollowListResponse.java
+++ b/src/main/java/com/instagram/backend/domain/follow/dto/FollowListResponse.java
@@ -1,0 +1,46 @@
+package com.instagram.backend.domain.follow.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.instagram.backend.domain.member.entity.Member;
+import lombok.Builder;
+import lombok.Getter;
+
+/*
+  FollowListResponse — 팔로워/팔로잉 목록의 각 항목 DTO
+
+  팔로워 목록과 팔로잉 목록 모두 같은 형태로 응답
+    — 유저의 기본 정보만 보여줌 (member_id, username, name, image_url)
+    — 프로필의 모든 정보(bio, phone 등)는 불필요 → 필요한 것만 담는 것이 DTO의 역할
+
+  is_following:
+    — "내가 이 유저를 팔로우하고 있는지" 여부
+    — 팔로워 목록에서 "맞팔하기" 버튼을 보여줄지 결정할 때 사용
+    — 이미 팔로우 중이면 "팔로잉" 표시, 아니면 "팔로우" 버튼 표시
+*/
+@Getter
+@Builder
+public class FollowListResponse {
+
+    @JsonProperty("member_id")
+    private Long memberId;
+
+    private String username;
+
+    private String name;
+
+    @JsonProperty("image_url")
+    private String imageUrl;
+
+    @JsonProperty("is_following")
+    private boolean isFollowing;
+
+    public static FollowListResponse of(Member member, boolean isFollowing) {
+        return FollowListResponse.builder()
+                .memberId(member.getMemberId())
+                .username(member.getUsername())
+                .name(member.getName())
+                .imageUrl(member.getImageUrl())
+                .isFollowing(isFollowing)
+                .build();
+    }
+}

--- a/src/main/java/com/instagram/backend/domain/follow/repository/FollowRepository.java
+++ b/src/main/java/com/instagram/backend/domain/follow/repository/FollowRepository.java
@@ -3,6 +3,11 @@ package com.instagram.backend.domain.follow.repository;
 import com.instagram.backend.domain.follow.entity.Follow;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.Optional;
+
 /*
   FollowRepository — follows 테이블에 접근하는 Repository
 
@@ -24,6 +29,36 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
     boolean existsByFollowerIdAndFollowingId(Long followerId, Long followingId);
 
     // 팔로우 관계를 조회 — 언팔로우 시 삭제할 Follow 엔티티를 찾기 위해 사용
-    // Optional: 관계가 없을 수도 있으므로 null-safe 처리
-    java.util.Optional<Follow> findByFollowerIdAndFollowingId(Long followerId, Long followingId);
+    Optional<Follow> findByFollowerIdAndFollowingId(Long followerId, Long followingId);
+
+    /*
+      커서 기반 팔로워 목록 조회
+      — followingId로 "이 유저를 팔로우하는 사람들" 조회
+      — followIdLessThan: 이전 페이지의 마지막 follow_id보다 작은 것만 (커서)
+      — OrderByFollowIdDesc: 최신 팔로우부터 보여줌
+
+      Pageable 파라미터로 limit(몇 개 가져올지)를 제어
+        — Spring Data JPA 메서드 이름에 limit를 직접 넣을 수 없음
+        — 대신 Pageable(페이지 번호 + 사이즈)을 넘겨서 DB에서 LIMIT 처리
+        — 호출 시: PageRequest.of(0, limit) → 첫 페이지에서 limit개만 가져옴
+
+      Spring Data JPA 메서드 이름 규칙:
+        findBy + 조건 + OrderBy + 정렬기준 + Desc
+        → SELECT * FROM follows WHERE following_id = ? AND follow_id < ? ORDER BY follow_id DESC LIMIT ?
+    */
+    List<Follow> findByFollowingIdAndFollowIdLessThanOrderByFollowIdDesc(
+            Long followingId, Long followIdCursor, Pageable pageable);
+
+    // 첫 페이지용 (커서 없을 때) — 가장 최신 팔로워부터
+    List<Follow> findByFollowingIdOrderByFollowIdDesc(Long followingId, Pageable pageable);
+
+    /*
+      커서 기반 팔로잉 목록 조회
+      — followerId로 "이 유저가 팔로우하는 사람들" 조회
+    */
+    List<Follow> findByFollowerIdAndFollowIdLessThanOrderByFollowIdDesc(
+            Long followerId, Long followIdCursor, Pageable pageable);
+
+    // 첫 페이지용 (커서 없을 때)
+    List<Follow> findByFollowerIdOrderByFollowIdDesc(Long followerId, Pageable pageable);
 }

--- a/src/main/java/com/instagram/backend/domain/follow/service/FollowService.java
+++ b/src/main/java/com/instagram/backend/domain/follow/service/FollowService.java
@@ -1,14 +1,20 @@
 package com.instagram.backend.domain.follow.service;
 
+import com.instagram.backend.domain.follow.dto.FollowListResponse;
 import com.instagram.backend.domain.follow.entity.Follow;
 import com.instagram.backend.domain.follow.repository.FollowRepository;
 import com.instagram.backend.domain.member.entity.Member;
 import com.instagram.backend.domain.member.repository.MemberRepository;
+import com.instagram.backend.global.dto.CursorPageResponse;
 import com.instagram.backend.global.exception.BusinessException;
 import com.instagram.backend.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 /*
   FollowService — 팔로우/언팔로우 비즈니스 로직
@@ -100,6 +106,117 @@ public class FollowService {
         // 4. 양쪽 카운트 감소
         me.decrementFollowingCount();
         target.decrementFollowerCount();
+    }
+
+    /*
+      팔로워 목록 조회 (커서 기반 페이지네이션)
+
+      커서 페이지네이션 동작 원리:
+        1. 첫 요청: cursor=null → 가장 최신 팔로워부터 limit개 조회
+        2. 다음 요청: cursor=마지막follow_id → 그 ID보다 작은(이전) 것들 중 limit개 조회
+        3. 결과가 limit개보다 많으면(+1개 요청) → 다음 페이지가 있다는 뜻
+
+      왜 limit+1개를 조회하나?
+        — 20개를 요청했는데 21개가 나오면 → 다음 페이지 있음 (hasNext=true)
+        — 20개 이하로 나오면 → 마지막 페이지 (hasNext=false)
+        — 실제 응답에는 limit개만 담고, +1개는 hasNext 판별용으로만 사용
+
+      Follow → FollowListResponse 변환:
+        — Follow 엔티티에는 followerId/followingId(숫자)만 있음
+        — 프로필 정보(username, name 등)를 보여주려면 Member를 조회해야 함
+        — 팔로워 목록: followerId로 Member 조회 (나를 팔로우하는 사람)
+        — 팔로잉 목록: followingId로 Member 조회 (내가 팔로우하는 사람)
+    */
+    public CursorPageResponse<FollowListResponse> getFollowers(Long myMemberId, String username, String cursor, int limit) {
+        // 1. username으로 대상 Member 조회
+        Member target = findMemberByUsername(username);
+
+        // 2. limit 검증 (1~50)
+        validateLimit(limit);
+
+        // 3. 커서 기반으로 Follow 목록 조회 (+1개 더 조회해서 다음 페이지 여부 확인)
+        PageRequest pageRequest = PageRequest.of(0, limit + 1);
+        List<Follow> follows;
+
+        if (cursor == null) {
+            // 첫 페이지: 커서 없이 최신순으로
+            follows = followRepository.findByFollowingIdOrderByFollowIdDesc(target.getMemberId(), pageRequest);
+        } else {
+            // 다음 페이지: 커서(follow_id) 이전 데이터만
+            follows = followRepository.findByFollowingIdAndFollowIdLessThanOrderByFollowIdDesc(
+                    target.getMemberId(), Long.parseLong(cursor), pageRequest);
+        }
+
+        // 4. hasNext 판별 후 실제 응답 데이터는 limit개만
+        boolean hasNext = follows.size() > limit;
+        List<Follow> resultFollows = hasNext ? follows.subList(0, limit) : follows;
+
+        // 5. Follow → FollowListResponse 변환 (팔로워 = followerId로 Member 조회)
+        List<FollowListResponse> content = resultFollows.stream()
+                .map(follow -> {
+                    Member follower = findMemberById(follow.getFollowerId());
+                    boolean isFollowing = followRepository.existsByFollowerIdAndFollowingId(myMemberId, follower.getMemberId());
+                    return FollowListResponse.of(follower, isFollowing);
+                })
+                .collect(Collectors.toList());
+
+        // 6. 다음 커서 = 마지막 항목의 follow_id
+        String nextCursor = hasNext ? String.valueOf(resultFollows.get(resultFollows.size() - 1).getFollowId()) : null;
+
+        return CursorPageResponse.of(content, nextCursor, hasNext);
+    }
+
+    /*
+      팔로잉 목록 조회 — 팔로워 목록과 구조 동일, 조회 방향만 반대
+      — 팔로워: followingId로 검색 → followerId의 Member 정보 반환
+      — 팔로잉: followerId로 검색 → followingId의 Member 정보 반환
+    */
+    public CursorPageResponse<FollowListResponse> getFollowing(Long myMemberId, String username, String cursor, int limit) {
+        Member target = findMemberByUsername(username);
+        validateLimit(limit);
+
+        PageRequest pageRequest = PageRequest.of(0, limit + 1);
+        List<Follow> follows;
+
+        if (cursor == null) {
+            follows = followRepository.findByFollowerIdOrderByFollowIdDesc(target.getMemberId(), pageRequest);
+        } else {
+            follows = followRepository.findByFollowerIdAndFollowIdLessThanOrderByFollowIdDesc(
+                    target.getMemberId(), Long.parseLong(cursor), pageRequest);
+        }
+
+        boolean hasNext = follows.size() > limit;
+        List<Follow> resultFollows = hasNext ? follows.subList(0, limit) : follows;
+
+        // 팔로잉 = followingId로 Member 조회 (내가 팔로우하는 사람)
+        List<FollowListResponse> content = resultFollows.stream()
+                .map(follow -> {
+                    Member following = findMemberById(follow.getFollowingId());
+                    boolean isFollowing = followRepository.existsByFollowerIdAndFollowingId(myMemberId, following.getMemberId());
+                    return FollowListResponse.of(following, isFollowing);
+                })
+                .collect(Collectors.toList());
+
+        String nextCursor = hasNext ? String.valueOf(resultFollows.get(resultFollows.size() - 1).getFollowId()) : null;
+
+        return CursorPageResponse.of(content, nextCursor, hasNext);
+    }
+
+    /*
+      limit 검증 — API 명세에 따라 1~50 범위만 허용
+    */
+    private void validateLimit(int limit) {
+        if (limit < 1 || limit > 50) {
+            throw new BusinessException(ErrorCode.INVALID_LIMIT);
+        }
+    }
+
+    /*
+      username으로 Member 조회 (삭제되지 않은 유저만)
+    */
+    private Member findMemberByUsername(String username) {
+        return memberRepository.findByMemberUsernameAndIsDeletedFalse(username)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
     }
 
     /*

--- a/src/main/java/com/instagram/backend/global/dto/CursorPageResponse.java
+++ b/src/main/java/com/instagram/backend/global/dto/CursorPageResponse.java
@@ -1,0 +1,49 @@
+package com.instagram.backend.global.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+/*
+  CursorPageResponse — 커서 기반 페이지네이션 공용 응답 DTO
+
+  왜 offset 방식이 아니라 cursor 방식을 사용하나?
+    — offset 방식: "10번째부터 20개 줘" → 데이터가 많아지면 느려짐 (DB가 앞의 10개를 건너뛰어야 함)
+    — cursor 방식: "이 ID 이후로 20개 줘" → 항상 일정한 속도 (인덱스를 타므로)
+    — 인스타그램처럼 무한 스크롤이 필요한 서비스에 적합
+
+  제네릭 <T>를 사용하는 이유:
+    — 팔로워 목록, 팔로잉 목록, 게시물 목록 등 다양한 곳에서 재사용
+    — T에 FollowListResponse, PostResponse 등 어떤 타입이든 넣을 수 있음
+    — ApiResponse<T>와 같은 원리
+
+  next_cursor:
+    — 다음 페이지를 요청할 때 보내야 할 커서 값
+    — null이면 더 이상 데이터가 없다는 뜻 (마지막 페이지)
+
+  has_next:
+    — 다음 페이지가 있는지 여부
+    — 프론트엔드가 "더 보기" 버튼을 보여줄지 결정할 때 사용
+*/
+@Getter
+@Builder
+public class CursorPageResponse<T> {
+
+    private List<T> content;
+
+    @JsonProperty("next_cursor")
+    private String nextCursor;
+
+    @JsonProperty("has_next")
+    private boolean hasNext;
+
+    public static <T> CursorPageResponse<T> of(List<T> content, String nextCursor, boolean hasNext) {
+        return CursorPageResponse.<T>builder()
+                .content(content)
+                .nextCursor(nextCursor)
+                .hasNext(hasNext)
+                .build();
+    }
+}


### PR DESCRIPTION
  - CursorPageResponse 공용 DTO 생성 (커서 기반 페이지네이션)
  - FollowListResponse DTO 생성 (팔로워/팔로잉 항목)
  - FollowRepository에 커서 기반 조회 메서드 추가 (Pageable 활용)
  - FollowService에 getFollowers/getFollowing 메서드 추가
  - FollowController에 GET 엔드포인트 2개 추가

  closes #23