### PR TITLE
fixDetail

### DIFF
--- a/src/main/java/com/instagram/backend/domain/bookmark/service/BookmarkService.java
+++ b/src/main/java/com/instagram/backend/domain/bookmark/service/BookmarkService.java
@@ -37,5 +37,6 @@ public class BookmarkService {
 
         Bookmark bookmark = bookmarkRepository.findByPostIdAndMemberId(postId, memberId)
                 .orElseThrow(()-> new BusinessException(ErrorCode.BOOKMARK_NOT_FOUND));
+        bookmarkRepository.delete(bookmark); // 저장 취소
     }
 }

--- a/src/main/java/com/instagram/backend/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/instagram/backend/domain/comment/repository/CommentRepository.java
@@ -1,0 +1,8 @@
+package com.instagram.backend.domain.comment.repository;
+
+import com.instagram.backend.domain.comment.entity.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+    int countByPostIdAndIsDeletedFalse(Long postId);
+}

--- a/src/main/java/com/instagram/backend/domain/post/controller/PostController.java
+++ b/src/main/java/com/instagram/backend/domain/post/controller/PostController.java
@@ -27,9 +27,10 @@ public class PostController {
     // 게시물 단건 조회 — GET /api/posts/{postId}
     @GetMapping("/{postId}")
     public ResponseEntity<ApiResponse<PostResponse>> getPost(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable Long postId) {
         return ResponseEntity.ok(
-                ApiResponse.success(postService.getPost(postId), "게시물 조회 성공")
+                ApiResponse.success(postService.getPost(userDetails.getMemberId(), postId), "게시물 조회 성공")
         );
     }
 
@@ -45,12 +46,13 @@ public class PostController {
 
     // 게시물 수정 — PATCH /api/posts/{postId}
     @PatchMapping("/{postId}")
-    public ResponseEntity<ApiResponse<PostResponse>> updatePost(
+    public ResponseEntity<ApiResponse<Void>> updatePost(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable Long postId,
             @RequestBody PostUpdateRequest request) {
+        postService.updatePost(userDetails.getMemberId(), postId, request);
         return ResponseEntity.ok(
-                ApiResponse.success(postService.updatePost(userDetails.getMemberId(), postId, request), "게시물이 수정되었습니다.")
+                ApiResponse.success(null, "게시물이 수정되었습니다.")
         );
     }
 
@@ -99,7 +101,7 @@ public class PostController {
     public ResponseEntity<ApiResponse<Void>> unbookmarkPost(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable Long postId){
-        bookmarkService.bookmarkPost(userDetails.getMemberId(), postId);
-        return ResponseEntity.ok(ApiResponse.success(null, "게시물이 저장이 취소되었습니다."));
+        bookmarkService.unbookmarkPost(userDetails.getMemberId(), postId);
+        return ResponseEntity.ok(ApiResponse.success(null, "게시물 저장이 취소되었습니다."));
     }
 }

--- a/src/main/java/com/instagram/backend/domain/post/dto/PostResponse.java
+++ b/src/main/java/com/instagram/backend/domain/post/dto/PostResponse.java
@@ -1,10 +1,13 @@
 package com.instagram.backend.domain.post.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.instagram.backend.domain.member.entity.Member;
 import com.instagram.backend.domain.post.entity.Post;
+import com.instagram.backend.domain.post.entity.PostImage;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
 public class PostResponse {
@@ -12,14 +15,8 @@ public class PostResponse {
     @JsonProperty("post_id")
     private final Long postId;
 
-    @JsonProperty("member_id")
-    private final Long memberId;
-
-    @JsonProperty("member_username")
-    private final String memberUsername;
-
-    @JsonProperty("post_contents")
-    private final String postContents;
+    @JsonProperty("content")
+    private final String content;
 
     @JsonProperty("comment_enabled")
     private final boolean commentEnabled;
@@ -27,20 +24,82 @@ public class PostResponse {
     @JsonProperty("like_count")
     private final int likeCount;
 
+    @JsonProperty("comment_count")
+    private final int commentCount;
+
+    @JsonProperty("is_liked")
+    private final boolean liked;
+
+    @JsonProperty("is_bookmarked")
+    private final boolean bookmarked;
+
     @JsonProperty("created_at")
     private final LocalDateTime createdAt;
 
-    public static PostResponse from(Post post) {
-        return new PostResponse(post);
+    @JsonProperty("images")
+    private final List<ImageInfo> images;
+
+    @JsonProperty("member")
+    private final MemberInfo member;
+
+    public static PostResponse of(Post post, List<PostImage> images,
+                                  boolean isLiked, boolean isBookmarked, int commentCount) {
+        return new PostResponse(post, images, isLiked, isBookmarked, commentCount);
     }
 
-    private PostResponse(Post post) {
+    private PostResponse(Post post, List<PostImage> images,
+                         boolean isLiked, boolean isBookmarked, int commentCount) {
         this.postId = post.getPostId();
-        this.memberId = post.getMember().getId();
-        this.memberUsername = post.getMember().getMemberUsername();
-        this.postContents = post.getContents();
+        this.content = post.getContents();
         this.commentEnabled = post.isCommentEnabled();
         this.likeCount = post.getLikeCount();
+        this.commentCount = commentCount;
+        this.liked = isLiked;
+        this.bookmarked = isBookmarked;
         this.createdAt = post.getCreatedAt();
+        this.images = images.stream().map(ImageInfo::from).toList();
+        this.member = MemberInfo.from(post.getMember());
+    }
+
+    @Getter
+    public static class ImageInfo {
+
+        @JsonProperty("image_url")
+        private final String imageUrl;
+
+        @JsonProperty("sort_order")
+        private final int sortOrder;
+
+        private ImageInfo(String imageUrl, int sortOrder) {
+            this.imageUrl = imageUrl;
+            this.sortOrder = sortOrder;
+        }
+
+        public static ImageInfo from(PostImage postImage) {
+            return new ImageInfo(postImage.getImageUrl(), postImage.getSortOrder());
+        }
+    }
+
+    @Getter
+    public static class MemberInfo {
+
+        @JsonProperty("member_id")
+        private final Long memberId;
+
+        @JsonProperty("username")
+        private final String username;
+
+        @JsonProperty("image_url")
+        private final String imageUrl;
+
+        private MemberInfo(Long memberId, String username, String imageUrl) {
+            this.memberId = memberId;
+            this.username = username;
+            this.imageUrl = imageUrl;
+        }
+
+        public static MemberInfo from(Member member) {
+            return new MemberInfo(member.getId(), member.getMemberUsername(), member.getImageUrl());
+        }
     }
 }

--- a/src/main/java/com/instagram/backend/domain/post/service/PostService.java
+++ b/src/main/java/com/instagram/backend/domain/post/service/PostService.java
@@ -1,5 +1,7 @@
 package com.instagram.backend.domain.post.service;
 
+import com.instagram.backend.domain.bookmark.repository.BookmarkRepository;
+import com.instagram.backend.domain.comment.repository.CommentRepository;
 import com.instagram.backend.domain.member.entity.Member;
 import com.instagram.backend.domain.member.repository.MemberRepository;
 import com.instagram.backend.domain.post.dto.PostCreateRequest;
@@ -9,12 +11,15 @@ import com.instagram.backend.domain.post.dto.PostUpdateRequest;
 import com.instagram.backend.domain.post.entity.Post;
 import com.instagram.backend.domain.post.entity.PostImage;
 import com.instagram.backend.domain.post.repository.PostImageRepository;
+import com.instagram.backend.domain.post.repository.PostLikeRepository;
 import com.instagram.backend.domain.post.repository.PostRepository;
 import com.instagram.backend.global.exception.BusinessException;
 import com.instagram.backend.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -23,13 +28,22 @@ public class PostService {
 
     private final PostRepository postRepository;
     private final PostImageRepository postImageRepository;
+    private final PostLikeRepository postLikeRepository;
+    private final BookmarkRepository bookmarkRepository;
+    private final CommentRepository commentRepository;
     private final MemberRepository memberRepository;
 
     // 게시물 단건 조회
-    public PostResponse getPost(Long postId) {
+    public PostResponse getPost(Long memberId, Long postId) {
         Post post = postRepository.findByPostIdAndIsDeletedFalse(postId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.POST_NOT_FOUND));
-        return PostResponse.from(post);
+
+        List<PostImage> images = postImageRepository.findByPostPostIdOrderBySortOrderAsc(postId);
+        boolean isLiked = postLikeRepository.existsByPostIdAndMemberId(postId, memberId);
+        boolean isBookmarked = bookmarkRepository.existsByPostIdAndMemberId(postId, memberId);
+        int commentCount = commentRepository.countByPostIdAndIsDeletedFalse(postId);
+
+        return PostResponse.of(post, images, isLiked, isBookmarked, commentCount);
     }
 
     // 게시물 생성
@@ -79,7 +93,7 @@ public class PostService {
 
     // 게시물 수정
     @Transactional
-    public PostResponse updatePost(Long memberId, Long postId, PostUpdateRequest request) {
+    public void updatePost(Long memberId, Long postId, PostUpdateRequest request) {
         // 내용 2200자 초과 검증
         if (request.getPostContents() != null && request.getPostContents().length() > 2200) {
             throw new BusinessException(ErrorCode.EXCEED_CONTENT_LENGTH);
@@ -94,7 +108,6 @@ public class PostService {
         }
 
         post.update(request.getPostContents(), request.isCommentEnabled());
-        return PostResponse.from(post);
     }
 
     // 게시물 삭제 (소프트 딜리트)
@@ -109,6 +122,5 @@ public class PostService {
         }
 
         post.softDelete();
-        // save() 불필요 — @Transactional 안에서 필드 변경 시 자동 UPDATE (Dirty Checking)
     }
 }

--- a/src/main/java/com/instagram/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/instagram/backend/global/config/SecurityConfig.java
@@ -30,6 +30,7 @@ public class SecurityConfig {
             "/api/auth/signup",
             "/api/auth/login",
             "/api/auth/refresh",
+            "/api/auth/logout",
             "/actuator/health",
             "/actuator/info"
     };


### PR DESCRIPTION
프론트 엔드의 요청사항에 맞춰서 수정한 거

 PR 설명 
  ## 변경 사항
  - 게시물 단건 조회 응답에 프론트엔드 요구 필드 추가
    - isLiked, isBookmarked, commentCount, images[], member{}

  ### 버그 수정
  - 로그아웃 API 401 에러 수정 (PUBLIC_URLS 누락)
  - 게시물 저장 취소 미작동 수정 (delete 누락)
  - 게시물 저장 취소 API 잘못된 메서드 호출 수정

  ### 구조 변경
  - PostResponse 필드명 ERD 기준으로 통일 (postContents → content)
  - 게시물 수정 응답 data: null 로 변경
