### PR TITLE
  feat: 프로필 조회 시 postCount를 실제 게시물 수로 연동

### DIFF
--- a/src/main/java/com/instagram/backend/domain/member/service/MemberService.java
+++ b/src/main/java/com/instagram/backend/domain/member/service/MemberService.java
@@ -1,6 +1,7 @@
 package com.instagram.backend.domain.member.service;
 
 import com.instagram.backend.domain.follow.repository.FollowRepository;
+import com.instagram.backend.domain.post.repository.PostRepository;
 import com.instagram.backend.domain.member.dto.*;
 import com.instagram.backend.domain.member.dto.ProfileImageUpdateRequest;
 import com.instagram.backend.domain.member.dto.ProfileImageUpdateResponse;
@@ -33,15 +34,16 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
     private final FollowRepository followRepository;
+    private final PostRepository postRepository;
 
     /*
       내 프로필 조회
       — JWT에서 추출한 memberId로 Member 조회
-      — postCount는 아직 Post 엔티티가 없으므로 0으로 반환 (TODO: Post 개발 후 연동)
+      — postCount: PostRepository에서 삭제되지 않은 게시물 수를 직접 조회
     */
     public MyProfileResponse getMyProfile(Long memberId) {
         Member member = findMemberById(memberId);
-        long postCount = 0; // TODO: postRepository.countByMemberIdAndIsDeletedFalse(memberId)
+        long postCount = postRepository.countByMemberMemberIdAndIsDeletedFalse(memberId);
         return MyProfileResponse.from(member, postCount);
     }
 
@@ -74,7 +76,7 @@ public class MemberService {
         Member member = memberRepository.findByMemberUsernameAndIsDeletedFalse(username)
                 .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
 
-        long postCount = 0; // TODO: postRepository.countByMemberIdAndIsDeletedFalse(member.getMemberId())
+        long postCount = postRepository.countByMemberMemberIdAndIsDeletedFalse(member.getMemberId());
         boolean isFollowing = followRepository.existsByFollowerIdAndFollowingId(myMemberId, member.getMemberId());
 
         return UserProfileResponse.from(member, postCount, isFollowing);

--- a/src/main/java/com/instagram/backend/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/instagram/backend/domain/post/repository/PostRepository.java
@@ -10,4 +10,8 @@ public interface PostRepository extends JpaRepository<Post, Long> {//<다룰 앤
     //Optional : Null 값 안전하게 처리
     //findByIdAndIsDeletedFalse : ID로 찾고 IsDeleted가 false 것만
     // Spring Data JPA는 메서드 이름만 규칙에 맞게 영어 문장처럼 지어주면, 알아서 DB가 이해할 수 있는 SQL 쿼리로 번역
+
+    // SELECT COUNT(*) FROM posts WHERE member_id = ? AND is_deleted = false
+    // → 특정 유저의 삭제되지 않은 게시물 수 (프로필의 "게시물 N" 표시용)
+    long countByMemberMemberIdAndIsDeletedFalse(Long memberId);
 }


### PR DESCRIPTION
  - PostRepository에 countByMemberMemberIdAndIsDeletedFalse()메서드 추가
  - MemberService에 PostRepository 의존성 주입 추가
  - getMyProfile() postCount 하드코딩(0) → 실제 쿼리 호출로 교체
  - getUserProfile() postCount 하드코딩(0) → 실제 쿼리 호출로 교체

  closes #27