### PR TITLE
  feat: 저장한 게시물 목록 조회 API 구현 (GET /api/users/me/bookmarks)

### DIFF
--- a/src/main/java/com/instagram/backend/domain/bookmark/controller/BookmarkController.java
+++ b/src/main/java/com/instagram/backend/domain/bookmark/controller/BookmarkController.java
@@ -1,0 +1,57 @@
+package com.instagram.backend.domain.bookmark.controller;
+
+import com.instagram.backend.domain.bookmark.dto.BookmarkPostResponse;
+import com.instagram.backend.domain.bookmark.service.BookmarkService;
+import com.instagram.backend.global.dto.ApiResponse;
+import com.instagram.backend.global.dto.CursorPageResponse;
+import com.instagram.backend.global.security.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/*
+  BookmarkController — 저장한 게시물 목록 조회 전용 컨트롤러
+
+  왜 PostController에 넣지 않고 별도 컨트롤러를 만들었나?
+    — PostController는 "게시물 자체"의 CRUD + 좋아요/북마크 토글을 담당
+    — "내가 저장한 게시물 목록"은 user의 컬렉션 조회 → /api/users/me/bookmarks 경로
+    — base path가 /api/users로 다르고, 도메인 책임도 bookmark 쪽이므로 분리가 자연스러움
+    — Spring은 같은 base path(/api/users)를 여러 컨트롤러가 공유 가능하므로 충돌 없음
+
+  왜 /me 경로를 사용하나?
+    — JWT에서 본인 식별이 가능하므로 URL에 member_id를 노출할 필요가 없음
+    — /me 패턴은 "현재 로그인한 사용자"를 나타내는 RESTful 관용구
+    — 보안적으로도 다른 사람의 북마크 목록은 조회 불가 (private 데이터)
+*/
+@RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
+public class BookmarkController {
+
+    private final BookmarkService bookmarkService;
+
+    /*
+      GET /api/users/me/bookmarks — 저장한 게시물 목록 조회
+
+      쿼리 파라미터:
+        — cursor (선택): 이전 페이지의 마지막 bookmark_id, 첫 페이지는 생략
+        — limit (선택, 기본 20): 한 번에 가져올 개수, 1~50 범위
+
+      응답: CursorPageResponse<BookmarkPostResponse>
+        — content: [{ post_id, thumbnail_url }, ...]
+        — next_cursor: 다음 페이지 요청 시 전달할 커서 (없으면 null)
+        — has_next: 다음 페이지 존재 여부
+    */
+    @GetMapping("/me/bookmarks")
+    public ApiResponse<CursorPageResponse<BookmarkPostResponse>> getMyBookmarks(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(required = false) String cursor,
+            @RequestParam(defaultValue = "20") int limit) {
+        CursorPageResponse<BookmarkPostResponse> response =
+                bookmarkService.getMyBookmarks(userDetails.getMemberId(), cursor, limit);
+        return ApiResponse.success(response, "저장한 게시물 목록 조회에 성공하였습니다.");
+    }
+}

--- a/src/main/java/com/instagram/backend/domain/bookmark/dto/BookmarkPostResponse.java
+++ b/src/main/java/com/instagram/backend/domain/bookmark/dto/BookmarkPostResponse.java
@@ -1,0 +1,33 @@
+package com.instagram.backend.domain.bookmark.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+/*
+  BookmarkPostResponse — "저장한 게시물 목록" 전용 응답 DTO
+
+  왜 PostResponse를 재사용하지 않고 새로 만들었나?
+    — 인스타그램 "저장됨" 화면은 썸네일 그리드 형태 (post_id + 대표 이미지만 필요)
+    — PostResponse에는 content, like_count, comment_count, member 등 무거운 필드가 많음
+    — 목록 API에서 그 모든 데이터를 매번 채우면 응답 크기 + 쿼리 수가 급증
+    — 상세 정보가 필요할 때만 GET /api/posts/{postId}로 추가 조회하는 패턴
+    — 트레이드오프: 응답 가벼움 ↔ 상세 보기 시 추가 요청 1회
+*/
+@Getter
+public class BookmarkPostResponse {
+
+    @JsonProperty("post_id")
+    private final Long postId;
+
+    @JsonProperty("thumbnail_url")
+    private final String thumbnailUrl;
+
+    private BookmarkPostResponse(Long postId, String thumbnailUrl) {
+        this.postId = postId;
+        this.thumbnailUrl = thumbnailUrl;
+    }
+
+    public static BookmarkPostResponse of(Long postId, String thumbnailUrl) {
+        return new BookmarkPostResponse(postId, thumbnailUrl);
+    }
+}

--- a/src/main/java/com/instagram/backend/domain/bookmark/repository/BookmarkRepository.java
+++ b/src/main/java/com/instagram/backend/domain/bookmark/repository/BookmarkRepository.java
@@ -1,13 +1,26 @@
 package com.instagram.backend.domain.bookmark.repository;
 
 import com.instagram.backend.domain.bookmark.entity.Bookmark;
-import com.instagram.backend.domain.post.entity.PostLike;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
     Optional<Bookmark> findByPostIdAndMemberId(Long postId, Long memberId);
 
     boolean existsByPostIdAndMemberId(Long postId, Long memberId);
+
+    // 저장한 게시물 목록 조회 (커서 페이지네이션 — 첫 페이지)
+    // SELECT * FROM bookmarks WHERE member_id = ? ORDER BY bookmark_id DESC LIMIT ?
+    // — bookmark_id는 AUTO_INCREMENT이므로 큰 ID일수록 최근에 저장한 것
+    // — 별도 created_at 컬럼 없이 PK 정렬만으로 "최근 저장순"을 구현 가능
+    List<Bookmark> findByMemberIdOrderByBookmarkIdDesc(Long memberId, Pageable pageable);
+
+    // 저장한 게시물 목록 조회 (커서 페이지네이션 — 두 번째 페이지부터)
+    // 이전 페이지의 마지막 bookmark_id보다 작은 것들만 조회
+    // — LessThan 조건으로 "이미 본 데이터 이후" 만 가져오는 게 커서 방식의 핵심
+    List<Bookmark> findByMemberIdAndBookmarkIdLessThanOrderByBookmarkIdDesc(
+            Long memberId, Long cursor, Pageable pageable);
 }

--- a/src/main/java/com/instagram/backend/domain/bookmark/service/BookmarkService.java
+++ b/src/main/java/com/instagram/backend/domain/bookmark/service/BookmarkService.java
@@ -1,13 +1,24 @@
 package com.instagram.backend.domain.bookmark.service;
 
+import com.instagram.backend.domain.bookmark.dto.BookmarkPostResponse;
 import com.instagram.backend.domain.bookmark.entity.Bookmark;
 import com.instagram.backend.domain.bookmark.repository.BookmarkRepository;
+import com.instagram.backend.domain.post.entity.Post;
+import com.instagram.backend.domain.post.entity.PostImage;
+import com.instagram.backend.domain.post.repository.PostImageRepository;
 import com.instagram.backend.domain.post.repository.PostRepository;
+import com.instagram.backend.global.dto.CursorPageResponse;
 import com.instagram.backend.global.exception.BusinessException;
 import com.instagram.backend.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -15,6 +26,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class BookmarkService {
 
     private final PostRepository postRepository;
+    private final PostImageRepository postImageRepository;
     private final BookmarkRepository bookmarkRepository;
 
     //게시물 저장
@@ -38,5 +50,105 @@ public class BookmarkService {
         Bookmark bookmark = bookmarkRepository.findByPostIdAndMemberId(postId, memberId)
                 .orElseThrow(()-> new BusinessException(ErrorCode.BOOKMARK_NOT_FOUND));
         bookmarkRepository.delete(bookmark); // 저장 취소
+    }
+
+    /*
+      저장한 게시물 목록 조회 (커서 기반 페이지네이션)
+
+      전체 흐름 — 3단계 배치 조회로 N+1 문제 회피
+        1) bookmarks 테이블에서 내가 저장한 (limit+1)개를 bookmark_id DESC 순으로 조회
+        2) 1단계에서 얻은 post_id 목록으로 posts 테이블 IN 조회 (삭제되지 않은 것만)
+        3) 2단계에서 살아있는 post_id 목록으로 post_images IN 조회 (대표 이미지 sort_order=0)
+
+      왜 이렇게 단계를 나누나?
+        — Bookmark 엔티티에는 post_id만 있고, Post와 PostImage는 별도 테이블
+        — 항목마다 개별 조회하면 20개 항목 → 1+20+20 = 41 쿼리 (N+1 문제)
+        — IN 절로 묶으면 → 1+1+1 = 3 쿼리만 발생
+
+      삭제된 게시물은 어떻게 처리하나?
+        — bookmarks에는 남아있지만 posts.is_deleted=true 인 경우
+        — 2단계 IN 조회에서 자동으로 제외됨
+        — 3단계 결과에도 안 들어가므로, 응답에는 살아있는 post들만 포함됨
+
+      커서 방식 (FollowService와 동일한 패턴):
+        — limit+1개를 조회해서 hasNext 판별
+        — 응답에는 limit개만 노출, 마지막 항목의 bookmark_id가 next_cursor
+    */
+    public CursorPageResponse<BookmarkPostResponse> getMyBookmarks(Long memberId, String cursor, int limit) {
+        // 1. limit 검증 (1~50)
+        validateLimit(limit);
+
+        // 2. 커서 기반 bookmarks 조회 (+1개로 hasNext 판별)
+        PageRequest pageRequest = PageRequest.of(0, limit + 1);
+        List<Bookmark> bookmarks;
+
+        if (cursor == null) {
+            // 첫 페이지
+            bookmarks = bookmarkRepository.findByMemberIdOrderByBookmarkIdDesc(memberId, pageRequest);
+        } else {
+            // 다음 페이지: 이전 커서보다 작은 bookmark_id만
+            bookmarks = bookmarkRepository.findByMemberIdAndBookmarkIdLessThanOrderByBookmarkIdDesc(
+                    memberId, Long.parseLong(cursor), pageRequest);
+        }
+
+        // 3. hasNext 판별 후 실제 limit개만 사용
+        boolean hasNext = bookmarks.size() > limit;
+        List<Bookmark> resultBookmarks = hasNext ? bookmarks.subList(0, limit) : bookmarks;
+
+        // 4. 빈 결과면 즉시 반환 (불필요한 쿼리 방지)
+        if (resultBookmarks.isEmpty()) {
+            return CursorPageResponse.of(new ArrayList<>(), null, false);
+        }
+
+        // 5. post_id 목록 추출 → posts IN 조회 (삭제된 것 제외)
+        List<Long> postIds = resultBookmarks.stream().map(Bookmark::getPostId).toList();
+        List<Post> posts = postRepository.findByPostIdInAndIsDeletedFalse(postIds);
+
+        // post_id → Post 매핑 (조회 결과를 Map으로 만들어 O(1) 룩업)
+        Map<Long, Post> postMap = new HashMap<>();
+        for (Post post : posts) {
+            postMap.put(post.getPostId(), post);
+        }
+
+        // 6. 살아있는 post_id로 대표 이미지(sort_order=0) IN 조회
+        List<Long> alivePostIds = posts.stream().map(Post::getPostId).toList();
+        Map<Long, String> thumbnailMap = new HashMap<>();
+        if (!alivePostIds.isEmpty()) {
+            List<PostImage> thumbnails = postImageRepository.findByPostPostIdInAndSortOrder(alivePostIds, 0);
+            for (PostImage image : thumbnails) {
+                thumbnailMap.put(image.getPost().getPostId(), image.getImageUrl());
+            }
+        }
+
+        // 7. bookmarks 순서대로 응답 DTO 생성 (삭제된 게시물은 자동 제외)
+        //    — bookmark_id DESC 순서를 유지해야 하므로 resultBookmarks를 기준으로 순회
+        List<BookmarkPostResponse> content = new ArrayList<>();
+        for (Bookmark bookmark : resultBookmarks) {
+            Post post = postMap.get(bookmark.getPostId());
+            if (post == null) {
+                continue; // 삭제된 게시물은 건너뜀
+            }
+            String thumbnailUrl = thumbnailMap.get(post.getPostId());
+            content.add(BookmarkPostResponse.of(post.getPostId(), thumbnailUrl));
+        }
+
+        // 8. next_cursor = 마지막 bookmark의 bookmark_id (정렬 기준이 bookmark_id이므로)
+        //    — 주의: post가 삭제돼서 content에서 제외돼도 cursor는 bookmarks 기준으로 산출
+        //      그래야 다음 페이지에서 누락 없이 이어서 조회됨
+        String nextCursor = hasNext
+                ? String.valueOf(resultBookmarks.get(resultBookmarks.size() - 1).getBookmarkId())
+                : null;
+
+        return CursorPageResponse.of(content, nextCursor, hasNext);
+    }
+
+    /*
+      limit 검증 — API 명세에 따라 1~50 범위만 허용
+      FollowService와 동일한 정책
+    */
+    private void validateLimit(int limit) {
+        if (limit < 1 || limit > 50) {
+            throw new BusinessException(ErrorCode.INVALID_LIMIT);
+        }
     }
 }

--- a/src/main/java/com/instagram/backend/domain/post/repository/PostImageRepository.java
+++ b/src/main/java/com/instagram/backend/domain/post/repository/PostImageRepository.java
@@ -3,9 +3,15 @@ package com.instagram.backend.domain.post.repository;
 import com.instagram.backend.domain.post.entity.PostImage;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Collection;
 import java.util.List;
 
 public interface PostImageRepository extends JpaRepository<PostImage, Long> {
     List<PostImage> findByPostPostIdOrderBySortOrderAsc(Long postId);
 
+    // 여러 게시물의 대표 이미지(sort_order=0)를 한 번의 쿼리로 조회
+    // SELECT * FROM post_images WHERE post_id IN (?, ?, ...) AND sort_order = ?
+    // — 북마크 목록 같은 썸네일 그리드 화면에서 N+1 문제를 막기 위해 사용
+    // — sort_order=0인 첫 번째 이미지가 인스타그램의 "대표 썸네일" 역할
+    List<PostImage> findByPostPostIdInAndSortOrder(Collection<Long> postIds, int sortOrder);
 }

--- a/src/main/java/com/instagram/backend/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/instagram/backend/domain/post/repository/PostRepository.java
@@ -3,10 +3,17 @@ package com.instagram.backend.domain.post.repository;
 import com.instagram.backend.domain.post.entity.Post;
 import org.springframework.data.jpa.repository.JpaRepository;// Spring Data JPA 기능 SQL을 짜지 않아도 기본적인 CRUD 자동 생성
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 public interface PostRepository extends JpaRepository<Post, Long> {//<다룰 앤티티,PK 타입> => save(), findAll(), delete() 바로 가져다 쓸 수 있
     Optional<Post> findByPostIdAndIsDeletedFalse(Long postId);
+
+    // SELECT * FROM posts WHERE post_id IN (?, ?, ...) AND is_deleted = false
+    // — 여러 post_id를 한 번의 쿼리로 조회 (N+1 문제 회피)
+    // — 북마크 목록 조회처럼 "관련 post들을 한 번에 가져와야 하는" 상황에 사용
+    List<Post> findByPostIdInAndIsDeletedFalse(Collection<Long> postIds);
     //Optional : Null 값 안전하게 처리
     //findByIdAndIsDeletedFalse : ID로 찾고 IsDeleted가 false 것만
     // Spring Data JPA는 메서드 이름만 규칙에 맞게 영어 문장처럼 지어주면, 알아서 DB가 이해할 수 있는 SQL 쿼리로 번역


### PR DESCRIPTION
  - BookmarkController 신규 생성, /api/users/me/bookmarks 엔드포인트 추가
  - BookmarkPostResponse DTO 신규 생성 (post_id + thumbnail_url 경량 응답)
  - BookmarkService.getMyBookmarks 구현, 3단계 배치 조회로 N+1 회피
  - BookmarkRepository에 커서 기반 조회 메서드 추가 (bookmark_id DESC)
  - PostRepository에 findByPostIdInAndIsDeletedFalse 추가
  - PostImageRepository에 대표 이미지(sort_order=0) 배치 조회 추가
  - 커서 페이지네이션(limit+1 방식)으로 hasNext 판별, 소프트 삭제된 게시물 자동 제외

  closes #31