### PR TITLE
feat: Story 도메인 구현 (#29)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ logs/
 
 # OMC (Claude Code 도구 상태 파일)
 .omc/
+
+# 로컬 계획 파일
+plan/

--- a/src/main/java/com/instagram/backend/domain/follow/repository/FollowRepository.java
+++ b/src/main/java/com/instagram/backend/domain/follow/repository/FollowRepository.java
@@ -2,6 +2,8 @@ package com.instagram.backend.domain.follow.repository;
 
 import com.instagram.backend.domain.follow.entity.Follow;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import org.springframework.data.domain.Pageable;
 
@@ -61,4 +63,8 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
 
     // 첫 페이지용 (커서 없을 때)
     List<Follow> findByFollowerIdOrderByFollowIdDesc(Long followerId, Pageable pageable);
+
+    // 내가 팔로우하는 사람들의 memberId 목록 조회 (스토리 피드용)
+    @Query("SELECT f.followingId FROM Follow f WHERE f.followerId = :followerId")
+    List<Long> findFollowingIdsByFollowerId(@Param("followerId") Long followerId);
 }

--- a/src/main/java/com/instagram/backend/domain/member/entity/Member.java
+++ b/src/main/java/com/instagram/backend/domain/member/entity/Member.java
@@ -17,7 +17,7 @@ public class Member extends BaseSoftDeleteEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "member_id")
-    private Long id;
+    private Long memberId;
 
     @Column(name = "member_user_id", unique = true)
     private String userId;
@@ -64,8 +64,7 @@ public class Member extends BaseSoftDeleteEntity {
     @Column(nullable = false)
     private Long followingCount = 0L;
 
-    // DTO 호환 getter (getMemberId, getUsername)
-    public Long getMemberId() { return this.id; }
+    // DTO 호환 getter
     public String getUsername() { return this.memberUsername; }
 
     @Builder

--- a/src/main/java/com/instagram/backend/domain/post/dto/PostResponse.java
+++ b/src/main/java/com/instagram/backend/domain/post/dto/PostResponse.java
@@ -99,7 +99,7 @@ public class PostResponse {
         }
 
         public static MemberInfo from(Member member) {
-            return new MemberInfo(member.getId(), member.getMemberUsername(), member.getImageUrl());
+            return new MemberInfo(member.getMemberId(), member.getMemberUsername(), member.getImageUrl());
         }
     }
 }

--- a/src/main/java/com/instagram/backend/domain/post/entity/PostImage.java
+++ b/src/main/java/com/instagram/backend/domain/post/entity/PostImage.java
@@ -15,7 +15,7 @@ public class PostImage {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "post_image_id")
-    private Long id;
+    private Long postImageId;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id", nullable = false)

--- a/src/main/java/com/instagram/backend/domain/post/entity/PostImage.java
+++ b/src/main/java/com/instagram/backend/domain/post/entity/PostImage.java
@@ -24,7 +24,7 @@ public class PostImage {
     @Column(name = "image_url", nullable = false, length = 500)
     private String imageUrl;
 
-    @Column(name = "image_type", length = 10)
+    @Column(name = "image_type", length = 50)
     private String imageType;
 
     @Column(name = "image_name", length = 255)

--- a/src/main/java/com/instagram/backend/domain/post/service/PostService.java
+++ b/src/main/java/com/instagram/backend/domain/post/service/PostService.java
@@ -103,7 +103,7 @@ public class PostService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.POST_NOT_FOUND));
 
         // 본인 게시물인지 확인
-        if (!post.getMember().getId().equals(memberId)) {
+        if (!post.getMember().getMemberId().equals(memberId)) {
             throw new BusinessException(ErrorCode.FORBIDDEN);
         }
 
@@ -117,7 +117,7 @@ public class PostService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.POST_NOT_FOUND));
 
         // 본인 게시물인지 확인
-        if (!post.getMember().getId().equals(memberId)) {
+        if (!post.getMember().getMemberId().equals(memberId)) {
             throw new BusinessException(ErrorCode.FORBIDDEN);
         }
 

--- a/src/main/java/com/instagram/backend/domain/story/controller/StoryController.java
+++ b/src/main/java/com/instagram/backend/domain/story/controller/StoryController.java
@@ -1,0 +1,62 @@
+package com.instagram.backend.domain.story.controller;
+
+import com.instagram.backend.domain.story.dto.*;
+import com.instagram.backend.domain.story.service.StoryService;
+import com.instagram.backend.global.dto.ApiResponse;
+import com.instagram.backend.global.security.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/stories")
+@RequiredArgsConstructor
+public class StoryController {
+
+    private final StoryService storyService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<StoryCreateResponse>> createStory(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody StoryCreateRequest request) {
+        StoryCreateResponse response = storyService.createStory(userDetails.getMemberId(), request);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success(response, "스토리가 업로드되었습니다."));
+    }
+
+    // /feed 를 /{storyId} 보다 먼저 선언해야 경로 충돌 방지
+    @GetMapping("feed")
+    public ResponseEntity<ApiResponse<List<StoryFeedResponse>>> getStoryFeed(
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        List<StoryFeedResponse> response = storyService.getStoryFeed(userDetails.getMemberId());
+        return ResponseEntity.ok(ApiResponse.success(response, "스토리 피드 조회 성공"));
+    }
+
+    @GetMapping("/{storyId}")
+    public ResponseEntity<ApiResponse<StoryResponse>> getStory(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long storyId) {
+        StoryResponse response = storyService.getStory(userDetails.getMemberId(), storyId);
+        return ResponseEntity.ok(ApiResponse.success(response, "스토리 조회 성공"));
+    }
+
+    @DeleteMapping("/{storyId}")
+    public ResponseEntity<ApiResponse<Void>> deleteStory(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long storyId) {
+        storyService.deleteStory(userDetails.getMemberId(), storyId);
+        return ResponseEntity.ok(ApiResponse.success(null, "스토리가 삭제되었습니다."));
+    }
+
+    @GetMapping("/{storyId}/visitors")
+    public ResponseEntity<ApiResponse<List<StoryVisitorResponse>>> getStoryVisitors(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long storyId) {
+        List<StoryVisitorResponse> response = storyService.getStoryVisitors(userDetails.getMemberId(), storyId);
+        return ResponseEntity.ok(ApiResponse.success(response, "방문자 목록 조회 성공"));
+    }
+}

--- a/src/main/java/com/instagram/backend/domain/story/dto/StoryCreateRequest.java
+++ b/src/main/java/com/instagram/backend/domain/story/dto/StoryCreateRequest.java
@@ -1,0 +1,22 @@
+package com.instagram.backend.domain.story.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class StoryCreateRequest {
+
+    @JsonProperty("story_image_url")
+    private String imageUrl;
+
+    @JsonProperty("story_image_type")
+    private String imageType;
+
+    @JsonProperty("story_image_name")
+    private String imageName;
+
+    @JsonProperty("story_image_uuid")
+    private String imageUuid;
+}

--- a/src/main/java/com/instagram/backend/domain/story/dto/StoryCreateResponse.java
+++ b/src/main/java/com/instagram/backend/domain/story/dto/StoryCreateResponse.java
@@ -1,0 +1,26 @@
+package com.instagram.backend.domain.story.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.instagram.backend.domain.story.entity.Story;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class StoryCreateResponse {
+
+    @JsonProperty("story_id")
+    private final Long storyId;
+
+    @JsonProperty("story_upload_date")
+    private final LocalDateTime storyUploadDate;
+
+    private StoryCreateResponse(Long storyId, LocalDateTime storyUploadDate) {
+        this.storyId = storyId;
+        this.storyUploadDate = storyUploadDate;
+    }
+
+    public static StoryCreateResponse from(Story story) {
+        return new StoryCreateResponse(story.getStoryId(), story.getCreatedAt());
+    }
+}

--- a/src/main/java/com/instagram/backend/domain/story/dto/StoryFeedResponse.java
+++ b/src/main/java/com/instagram/backend/domain/story/dto/StoryFeedResponse.java
@@ -1,0 +1,37 @@
+package com.instagram.backend.domain.story.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.instagram.backend.domain.member.entity.Member;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class StoryFeedResponse {
+
+    @JsonProperty("member_id")
+    private final Long memberId;
+
+    private final String username;
+
+    @JsonProperty("profile_image_url")
+    private final String profileImageUrl;
+
+    private final List<StoryResponse> stories;
+
+    private StoryFeedResponse(Long memberId, String username, String profileImageUrl, List<StoryResponse> stories) {
+        this.memberId = memberId;
+        this.username = username;
+        this.profileImageUrl = profileImageUrl;
+        this.stories = stories;
+    }
+
+    public static StoryFeedResponse of(Member member, List<StoryResponse> stories) {
+        return new StoryFeedResponse(
+                member.getMemberId(),
+                member.getUsername(),
+                member.getImageUrl(),
+                stories
+        );
+    }
+}

--- a/src/main/java/com/instagram/backend/domain/story/dto/StoryResponse.java
+++ b/src/main/java/com/instagram/backend/domain/story/dto/StoryResponse.java
@@ -1,0 +1,45 @@
+package com.instagram.backend.domain.story.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.instagram.backend.domain.story.entity.Story;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class StoryResponse {
+
+    @JsonProperty("story_id")
+    private final Long storyId;
+
+    @JsonProperty("member_id")
+    private final Long memberId;
+
+    @JsonProperty("image_url")
+    private final String imageUrl;
+
+    @JsonProperty("created_at")
+    private final LocalDateTime createdAt;
+
+    @JsonProperty("expires_at")
+    private final LocalDateTime expiresAt;
+
+    private StoryResponse(Long storyId, Long memberId, String imageUrl,
+                          LocalDateTime createdAt, LocalDateTime expiresAt) {
+        this.storyId = storyId;
+        this.memberId = memberId;
+        this.imageUrl = imageUrl;
+        this.createdAt = createdAt;
+        this.expiresAt = expiresAt;
+    }
+
+    public static StoryResponse from(Story story) {
+        return new StoryResponse(
+                story.getStoryId(),
+                story.getMemberId(),
+                story.getImageUrl(),
+                story.getCreatedAt(),
+                story.getExpiresAt()
+        );
+    }
+}

--- a/src/main/java/com/instagram/backend/domain/story/dto/StoryVisitorResponse.java
+++ b/src/main/java/com/instagram/backend/domain/story/dto/StoryVisitorResponse.java
@@ -1,0 +1,39 @@
+package com.instagram.backend.domain.story.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.instagram.backend.domain.member.entity.Member;
+import com.instagram.backend.domain.story.entity.StoryVisitor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class StoryVisitorResponse {
+
+    @JsonProperty("member_id")
+    private final Long memberId;
+
+    private final String username;
+
+    @JsonProperty("profile_image_url")
+    private final String profileImageUrl;
+
+    @JsonProperty("visited_at")
+    private final LocalDateTime visitedAt;
+
+    private StoryVisitorResponse(Long memberId, String username, String profileImageUrl, LocalDateTime visitedAt) {
+        this.memberId = memberId;
+        this.username = username;
+        this.profileImageUrl = profileImageUrl;
+        this.visitedAt = visitedAt;
+    }
+
+    public static StoryVisitorResponse of(StoryVisitor visitor, Member member) {
+        return new StoryVisitorResponse(
+                member.getMemberId(),
+                member.getUsername(),
+                member.getImageUrl(),
+                visitor.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/instagram/backend/domain/story/entity/Story.java
+++ b/src/main/java/com/instagram/backend/domain/story/entity/Story.java
@@ -25,7 +25,7 @@ public class Story extends BaseSoftDeleteEntity {
     @Column(nullable = false, length = 500)
     private String imageUrl;
 
-    @Column(length = 10)
+    @Column(length = 50)
     private String imageType;
 
     @Column(length = 255)

--- a/src/main/java/com/instagram/backend/domain/story/entity/StoryVisitor.java
+++ b/src/main/java/com/instagram/backend/domain/story/entity/StoryVisitor.java
@@ -1,5 +1,6 @@
 package com.instagram.backend.domain.story.entity;
 
+import com.instagram.backend.global.entity.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -10,7 +11,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "story_visitors")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class StoryVisitor {
+public class StoryVisitor extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/instagram/backend/domain/story/repository/StoryRepository.java
+++ b/src/main/java/com/instagram/backend/domain/story/repository/StoryRepository.java
@@ -1,0 +1,14 @@
+package com.instagram.backend.domain.story.repository;
+
+import com.instagram.backend.domain.story.entity.Story;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface StoryRepository extends JpaRepository<Story, Long> {
+
+    Optional<Story> findByStoryIdAndIsDeletedFalse(Long storyId);
+
+    List<Story> findByMemberIdInAndIsDeletedFalseOrderByCreatedAtDesc(List<Long> memberIds);
+}

--- a/src/main/java/com/instagram/backend/domain/story/repository/StoryVisitorRepository.java
+++ b/src/main/java/com/instagram/backend/domain/story/repository/StoryVisitorRepository.java
@@ -1,0 +1,13 @@
+package com.instagram.backend.domain.story.repository;
+
+import com.instagram.backend.domain.story.entity.StoryVisitor;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface StoryVisitorRepository extends JpaRepository<StoryVisitor, Long> {
+
+    boolean existsByStoryIdAndMemberId(Long storyId, Long memberId);
+
+    List<StoryVisitor> findByStoryIdOrderByCreatedAtDesc(Long storyId);
+}

--- a/src/main/java/com/instagram/backend/domain/story/service/StoryService.java
+++ b/src/main/java/com/instagram/backend/domain/story/service/StoryService.java
@@ -1,0 +1,157 @@
+package com.instagram.backend.domain.story.service;
+
+import com.instagram.backend.domain.follow.repository.FollowRepository;
+import com.instagram.backend.domain.member.entity.Member;
+import com.instagram.backend.domain.member.repository.MemberRepository;
+import com.instagram.backend.domain.story.dto.*;
+import com.instagram.backend.domain.story.entity.Story;
+import com.instagram.backend.domain.story.entity.StoryVisitor;
+import com.instagram.backend.domain.story.repository.StoryRepository;
+import com.instagram.backend.domain.story.repository.StoryVisitorRepository;
+import com.instagram.backend.global.exception.BusinessException;
+import com.instagram.backend.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class StoryService {
+
+    private static final Set<String> ALLOWED_IMAGE_TYPES = Set.of(
+            "image/jpeg", "image/png", "image/gif", "image/webp"
+    );
+
+    private final StoryRepository storyRepository;
+    private final StoryVisitorRepository storyVisitorRepository;
+    private final FollowRepository followRepository;
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public StoryCreateResponse createStory(Long memberId, StoryCreateRequest request) {
+        if (request.getImageUrl() == null || request.getImageUrl().isBlank()) {
+            throw new BusinessException(ErrorCode.MISSING_REQUIRED_FIELD);
+        }
+        validateImageType(request.getImageType());
+
+        Story story = Story.builder()
+                .memberId(memberId)
+                .imageUrl(request.getImageUrl())
+                .imageType(request.getImageType())
+                .imageName(request.getImageName())
+                .imageUuid(request.getImageUuid())
+                .expiresAt(LocalDateTime.now().plusHours(24))
+                .build();
+
+        storyRepository.save(story);
+        return StoryCreateResponse.from(story);
+    }
+
+    @Transactional
+    public StoryResponse getStory(Long memberId, Long storyId) {
+        Story story = findStory(storyId);
+
+        // TODO: BLOCKED_MEMBER — Block 도메인 구현 후 차단 관계 확인 추가
+
+        if (!story.getMemberId().equals(memberId)) {
+            if (!storyVisitorRepository.existsByStoryIdAndMemberId(storyId, memberId)) {
+                StoryVisitor visitor = StoryVisitor.builder()
+                        .storyId(storyId)
+                        .memberId(memberId)
+                        .build();
+                storyVisitorRepository.save(visitor);
+            }
+        }
+
+        return StoryResponse.from(story);
+    }
+
+    @Transactional
+    public void deleteStory(Long memberId, Long storyId) {
+        Story story = findStory(storyId);
+        checkOwner(story, memberId);
+        story.softDelete();
+    }
+
+    public List<StoryFeedResponse> getStoryFeed(Long memberId) {
+        List<Long> followingIds = followRepository.findFollowingIdsByFollowerId(memberId);
+        if (followingIds.isEmpty()) {
+            return List.of();
+        }
+
+        List<Story> stories = storyRepository.findByMemberIdInAndIsDeletedFalseOrderByCreatedAtDesc(followingIds);
+        if (stories.isEmpty()) {
+            return List.of();
+        }
+
+        List<Long> memberIds = stories.stream()
+                .map(Story::getMemberId)
+                .distinct()
+                .toList();
+
+        Map<Long, Member> memberMap = memberRepository.findAllById(memberIds)
+                .stream()
+                .collect(Collectors.toMap(Member::getMemberId, m -> m));
+
+        Map<Long, List<Story>> storiesByMember = stories.stream()
+                .collect(Collectors.groupingBy(Story::getMemberId));
+
+        return memberIds.stream()
+                .filter(memberMap::containsKey)
+                .map(id -> {
+                    List<StoryResponse> memberStories = storiesByMember.getOrDefault(id, List.of())
+                            .stream()
+                            .map(StoryResponse::from)
+                            .toList();
+                    return StoryFeedResponse.of(memberMap.get(id), memberStories);
+                })
+                .toList();
+    }
+
+    public List<StoryVisitorResponse> getStoryVisitors(Long memberId, Long storyId) {
+        Story story = findStory(storyId);
+        checkOwner(story, memberId);
+
+        List<StoryVisitor> visitors = storyVisitorRepository.findByStoryIdOrderByCreatedAtDesc(storyId);
+        if (visitors.isEmpty()) {
+            return List.of();
+        }
+
+        List<Long> visitorIds = visitors.stream()
+                .map(StoryVisitor::getMemberId)
+                .toList();
+
+        Map<Long, Member> memberMap = memberRepository.findAllById(visitorIds)
+                .stream()
+                .collect(Collectors.toMap(Member::getMemberId, m -> m));
+
+        return visitors.stream()
+                .filter(v -> memberMap.containsKey(v.getMemberId()))
+                .map(v -> StoryVisitorResponse.of(v, memberMap.get(v.getMemberId())))
+                .toList();
+    }
+
+    private Story findStory(Long storyId) {
+        return storyRepository.findByStoryIdAndIsDeletedFalse(storyId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.STORY_NOT_FOUND));
+    }
+
+    private void checkOwner(Story story, Long memberId) {
+        if (!story.getMemberId().equals(memberId)) {
+            throw new BusinessException(ErrorCode.STORY_ACCESS_DENIED);
+        }
+    }
+
+    private void validateImageType(String imageType) {
+        if (imageType == null || !ALLOWED_IMAGE_TYPES.contains(imageType)) {
+            throw new BusinessException(ErrorCode.INVALID_IMAGE_TYPE);
+        }
+    }
+}

--- a/src/main/java/com/instagram/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/instagram/backend/global/exception/ErrorCode.java
@@ -29,6 +29,8 @@ public enum ErrorCode {
     // 403 - 권한 오류
     AUTH_ACCESS_DENIED(403, "접근 권한이 없습니다."),
     FORBIDDEN(403, "본인의 게시물만 수정/삭제할 수 있습니다."),
+    STORY_ACCESS_DENIED(403, "본인의 스토리만 수정/삭제할 수 있습니다."),
+    BLOCKED_MEMBER(403, "차단된 사용자의 스토리입니다."),
 
     CANNOT_FOLLOW_SELF(400, "자기 자신을 팔로우할 수 없습니다."),
 
@@ -38,6 +40,7 @@ public enum ErrorCode {
     LIKE_NOT_FOUND(404, "좋아요 내역이 존재하지 않습니다."),
     BOOKMARK_NOT_FOUND(404, "저장 내역이 존재하지 않습니다."),
     FOLLOW_NOT_FOUND(404, "팔로우 관계가 존재하지 않습니다."),
+    STORY_NOT_FOUND(404, "존재하지 않는 스토리입니다."),
 
     // 409 - 중복
     DUPLICATE_EMAIL(409, "이미 사용 중인 이메일입니다."),


### PR DESCRIPTION
## 개요
이슈 #29 — Story 도메인 CRUD 구현

> 스토리 24시간 만료 스케줄러(#30)는 이번 PR 범위에서 제외.
> `expiresAt` 필드 저장만 처리.

---

## 구현 내용

### 신규 API

| Method | URL | 설명 | 응답 |
|--------|-----|------|------|
| POST | `/api/stories` | 스토리 생성 | 201 |
| GET | `/api/stories/feed` | 팔로잉 스토리 피드 | 200 |
| GET | `/api/stories/{storyId}` | 스토리 단건 조회 | 200 |
| DELETE | `/api/stories/{storyId}` | 스토리 삭제 | 200 |
| GET | `/api/stories/{storyId}/visitors` | 방문자 목록 (본인만) | 200 |

### 비즈니스 규칙
- 본인 스토리 조회 시 방문자 기록 저장 안 함
- 중복 방문자 기록 방지 (`existsByStoryIdAndMemberId`)
- 방문자 목록은 소유자만 조회 가능
- 차단 관계 확인: Block 도메인 미구현 → `getStory()`에 TODO 주석 처리

### 에러 코드 추가
| 코드 | HTTP | 메시지 |
|------|------|--------|
| `STORY_NOT_FOUND` | 404 | 존재하지 않는 스토리입니다. |
| `STORY_ACCESS_DENIED` | 403 | 본인의 스토리만 수정/삭제할 수 있습니다. |
| `BLOCKED_MEMBER` | 403 | 차단된 사용자의 스토리입니다. |

---

## 리팩토링

### Member / PostImage 엔티티 PK 필드명 통일
프로젝트 전체 네이밍 규칙 `{엔티티명}Id` 에 맞게 수정.

| 엔티티 | 변경 전 | 변경 후 |
|--------|---------|---------|
| `Member` | `private Long id` | `private Long memberId` |
| `PostImage` | `private Long id` | `private Long postImageId` |

- `PostService`, `PostResponse`, `PostRepository`, `MemberService` 참조 코드 동기화

---

## 기술적 선택

### N+1 방지
`getStoryFeed`, `getStoryVisitors`에서 Member 정보 조회 시 `memberRepository.findAllById()`로 한 번에 조회 후 Map 캐싱 적용.

```java
Map<Long, Member> memberMap = memberRepository.findAllById(memberIds)
    .stream()
    .collect(Collectors.toMap(Member::getMemberId, m -> m));
```

### /feed 경로 충돌 방지
`@GetMapping("feed")`를 `@GetMapping("/{storyId}")` 보다 먼저 선언.

---

## 테스트 체크리스트
- [x] 스토리 생성 → 201 + story_id, story_upload_date 반환
- [x] 단건 조회 → 타인 방문 시 방문자 기록 저장
- [x] 본인 조회 → 방문자 기록 저장 안 됨
- [x] 방문자 목록 → 소유자만 조회 가능
- [x] 피드 → 팔로잉한 사용자의 스토리 반환
- [x] 타인 스토리 삭제 → 403
- [x] 삭제 후 조회 → 404