### PR TITLE
  feat: 채팅방 메시지 전송 및 목록 조회 API 구현 (POST/GET /api/chats/{roomId}/messages)

### DIFF
--- a/src/main/java/com/instagram/backend/domain/chat/repository/ChatRoomMemberRepository.java
+++ b/src/main/java/com/instagram/backend/domain/chat/repository/ChatRoomMemberRepository.java
@@ -15,6 +15,19 @@ public interface ChatRoomMemberRepository extends JpaRepository<ChatRoomMember, 
     // → 내가 참여 중인 모든 chat_room_id를 얻기 위한 첫 단계
     List<ChatRoomMember> findByMemberId(Long memberId);
 
+    /*
+      특정 유저가 특정 채팅방의 참여자인지 확인
+
+      목적: 메시지 전송/조회 API의 참여자 권한 검증
+        — SELECT 1 FROM chat_room_members WHERE chat_room_id = ? AND member_id = ? LIMIT 1
+        — Spring Data JPA의 existsBy... 메서드는 존재 여부만 반환 (count 또는 limit 1)
+        — 전체 row를 JVM으로 끌어오는 findByChatRoomIdIn() + stream().anyMatch() 패턴의 대체
+
+      사용처:
+        — MessageService.sendMessage / getMessages 의 권한 검증
+    */
+    boolean existsByChatRoomIdAndMemberId(Long chatRoomId, Long memberId);
+
     // 여러 채팅방의 참여자 목록을 IN 절 배치 조회 (N+1 회피)
     // SELECT * FROM chat_room_members WHERE chat_room_id IN (?, ?, ...)
     // → 내가 속한 room들의 "다른 참여자" 정보를 한 번에 가져올 때 사용

--- a/src/main/java/com/instagram/backend/domain/chat/service/ChatService.java
+++ b/src/main/java/com/instagram/backend/domain/chat/service/ChatService.java
@@ -10,6 +10,7 @@ import com.instagram.backend.domain.member.entity.Member;
 import com.instagram.backend.domain.member.repository.MemberRepository;
 import com.instagram.backend.domain.message.entity.Message;
 import com.instagram.backend.domain.message.entity.MessageText;
+import com.instagram.backend.domain.message.entity.MessageType;
 import com.instagram.backend.domain.message.repository.MessageRepository;
 import com.instagram.backend.domain.message.repository.MessageTextRepository;
 import com.instagram.backend.global.exception.BusinessException;
@@ -44,10 +45,9 @@ import java.util.Set;
 @RequiredArgsConstructor
 public class ChatService {
 
-    // 메시지 타입 상수 — 매직 스트링 방지
+    // 채팅방 타입 상수 — 매직 스트링 방지
     private static final String CHAT_ROOM_TYPE_DM = "DM";
     private static final String CHAT_ROOM_TYPE_GROUP = "GROUP";
-    private static final String MESSAGE_TYPE_TEXT = "TEXT";
     // 미리보기 본문 최대 길이 (긴 텍스트 잘라서 전송 → 네트워크 절약)
     private static final int PREVIEW_MAX_LENGTH = 50;
 
@@ -238,7 +238,7 @@ public class ChatService {
             Optional<Message> latest = messageRepository.findTopByChatRoomIdAndIsDeletedFalseOrderByMessageIdDesc(roomId);
             latest.ifPresent(msg -> {
                 lastMessageByRoomId.put(roomId, msg);
-                if (MESSAGE_TYPE_TEXT.equals(msg.getMessageType())) {
+                if (MessageType.TEXT.name().equals(msg.getMessageType())) {
                     textMessageIds.add(msg.getMessageId());
                 }
             });

--- a/src/main/java/com/instagram/backend/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/instagram/backend/domain/member/repository/MemberRepository.java
@@ -13,6 +13,12 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByMemberUsernameAndIsDeletedFalse(String memberUsername);
 
+    // 단일 memberId 조회 (소프트 삭제된 계정 자동 제외)
+    // 메시지 전송 응답에 작성자 username/profileImageUrl을 담을 때 사용
+    // findById(Long)은 is_deleted 필터가 없어 탈퇴 계정의 정보가 노출될 수 있으므로
+    // 프로젝트 전반의 "findByXxxIdAndIsDeletedFalse" 패턴을 따름
+    Optional<Member> findByMemberIdAndIsDeletedFalse(Long memberId);
+
     boolean existsByEmail(String email);
 
     boolean existsByMemberUsername(String memberUsername);

--- a/src/main/java/com/instagram/backend/domain/message/controller/MessageController.java
+++ b/src/main/java/com/instagram/backend/domain/message/controller/MessageController.java
@@ -1,0 +1,103 @@
+package com.instagram.backend.domain.message.controller;
+
+import com.instagram.backend.domain.message.dto.request.MessageSendRequest;
+import com.instagram.backend.domain.message.dto.response.MessageResponse;
+import com.instagram.backend.domain.message.service.MessageService;
+import com.instagram.backend.global.dto.ApiResponse;
+import com.instagram.backend.global.dto.CursorPageResponse;
+import com.instagram.backend.global.exception.BusinessException;
+import com.instagram.backend.global.exception.ErrorCode;
+import com.instagram.backend.global.security.CustomUserDetails;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/*
+  MessageController — 채팅방 메시지 전송/조회 API
+
+  @RequestMapping("/api/chats/{roomId}/messages")
+    — 모든 엔드포인트가 특정 채팅방에 귀속된 리소스
+    — Chat 도메인의 메시지 관련 API를 별도 컨트롤러로 분리 (도메인 책임 분리)
+
+  인증:
+    — JWT 필터를 통해 인증된 사용자만 접근 가능
+    — @AuthenticationPrincipal로 memberId를 꺼내 서비스에 전달
+
+  @Valid 미사용:
+    — 전송 요청은 dtype에 따라 필수 필드가 달라지므로 Bean Validation만으로 처리 불가
+    — 서비스 레이어에서 dtype 분기 후 수동 검증
+*/
+@RestController
+@RequestMapping("/api/chats/{roomId}/messages")
+@RequiredArgsConstructor
+public class MessageController {
+
+    private final MessageService messageService;
+
+    /*
+      POST /api/chats/{roomId}/messages — 메시지 전송
+
+      응답 코드: 201 CREATED
+        — 신규 리소스 생성이므로 표준 Created 사용
+        — 채팅방 생성 API(#36)와 같은 패턴
+    */
+    @PostMapping
+    public ResponseEntity<ApiResponse<MessageResponse>> sendMessage(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long roomId,
+            @Valid @RequestBody MessageSendRequest request) {
+
+        // 인증 필터가 이미 통과시킨 상태라 userDetails는 non-null이 정상이지만,
+        // 향후 필터 설정 변경 시 NPE → 500 누출을 방지하기 위한 명시적 방어
+        if (userDetails == null) {
+            throw new BusinessException(ErrorCode.UNAUTHORIZED);
+        }
+
+        MessageResponse response = messageService.sendMessage(
+                userDetails.getMemberId(), roomId, request);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(
+                ApiResponse.success(response, "메시지가 전송되었습니다.")
+        );
+    }
+
+    /*
+      GET /api/chats/{roomId}/messages — 메시지 목록 조회 (커서 페이지네이션)
+
+      쿼리 파라미터:
+        — cursor: 이전 응답의 next_cursor. 최초 요청 시 생략
+        — limit : 한 페이지 크기 (생략 시 기본 30, 최대 100)
+
+      응답 구조(CursorPageResponse):
+        — content: MessageResponse 리스트 (messageId DESC 정렬)
+        — next_cursor: 다음 페이지 요청에 사용할 cursor (마지막 페이지면 null)
+        — has_next: 다음 페이지 존재 여부
+    */
+    @GetMapping
+    public ResponseEntity<ApiResponse<CursorPageResponse<MessageResponse>>> getMessages(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long roomId,
+            @RequestParam(required = false) String cursor,
+            @RequestParam(required = false) Integer limit) {
+
+        if (userDetails == null) {
+            throw new BusinessException(ErrorCode.UNAUTHORIZED);
+        }
+
+        CursorPageResponse<MessageResponse> response =
+                messageService.getMessages(userDetails.getMemberId(), roomId, cursor, limit);
+
+        return ResponseEntity.ok(
+                ApiResponse.success(response, "메시지 목록 조회에 성공하였습니다.")
+        );
+    }
+}

--- a/src/main/java/com/instagram/backend/domain/message/dto/request/MessageSendRequest.java
+++ b/src/main/java/com/instagram/backend/domain/message/dto/request/MessageSendRequest.java
@@ -1,0 +1,55 @@
+package com.instagram.backend.domain.message.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/*
+  MessageSendRequest — 메시지 전송 요청 DTO
+
+  설계 배경:
+    — 명세서(Chat.pdf) 상 dtype 값에 따라 요청 본문이 달라짐
+    — dtype = TEXT  : message_text_content 필드 사용
+    — dtype = IMAGE : message_image_url / message_image_type / message_image_name / message_image_uuid 사용
+    — dtype = POST  : post_id 사용
+    — dtype = STORY : story_visitor_id 사용 (명세서에서 이 이름을 씀 — 실제로는 story_id를 의미)
+    — 모든 타입을 하나의 DTO에 통합해서 받는 방식 (flat DTO)
+      → 다형 DTO(상속/polymorphic)보다 단순하고 Jackson 역직렬화가 간편
+
+  @NotBlank 같은 Bean Validation 어노테이션을 dtype별로 달 수 없으므로
+    서비스 레이어에서 dtype 분기 후 수동 검증한다.
+*/
+@Getter
+@NoArgsConstructor
+public class MessageSendRequest {
+
+    // TEXT / IMAGE / POST / STORY 중 하나
+    @JsonProperty("dtype")
+    private String dtype;
+
+    // --- TEXT 전용 ---
+    @JsonProperty("message_text_content")
+    private String messageTextContent;
+
+    // --- IMAGE 전용 ---
+    @JsonProperty("message_image_url")
+    private String messageImageUrl;
+
+    @JsonProperty("message_image_type")
+    private String messageImageType;
+
+    @JsonProperty("message_image_name")
+    private String messageImageName;
+
+    @JsonProperty("message_image_uuid")
+    private String messageImageUuid;
+
+    // --- POST 공유 전용 ---
+    @JsonProperty("post_id")
+    private Long postId;
+
+    // --- STORY 공유 전용 ---
+    // 명세서에서 story_visitor_id라는 이름을 쓰지만 서버 내부에서는 storyId로 취급
+    @JsonProperty("story_visitor_id")
+    private Long storyVisitorId;
+}

--- a/src/main/java/com/instagram/backend/domain/message/dto/response/MessageResponse.java
+++ b/src/main/java/com/instagram/backend/domain/message/dto/response/MessageResponse.java
@@ -1,0 +1,76 @@
+package com.instagram.backend.domain.message.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+/*
+  MessageResponse — 메시지 단건 표현 DTO
+
+  사용처:
+    — POST /api/chats/{roomId}/messages 응답 (data 필드)
+    — GET  /api/chats/{roomId}/messages 응답 content 리스트의 각 아이템
+
+  설계:
+    — 공통 필드(messageId, chatRoomId, senderId, 작성자 정보, messageType, createdAt)
+    — dtype별 부가 필드는 같은 DTO에 통합해서 null 허용으로 노출
+    — 프론트는 messageType 값으로 어떤 필드를 읽을지 분기
+
+  null 직렬화:
+    — Jackson 기본값(ALWAYS) 사용 — 필드가 null이어도 키는 항상 응답에 포함
+    — 프론트의 분기 로직이 단순해짐
+*/
+@Getter
+@Builder
+public class MessageResponse {
+
+    @JsonProperty("message_id")
+    private final Long messageId;
+
+    @JsonProperty("chat_room_id")
+    private final Long chatRoomId;
+
+    @JsonProperty("sender_id")
+    private final Long senderId;
+
+    @JsonProperty("sender_username")
+    private final String senderUsername;
+
+    @JsonProperty("sender_profile_image_url")
+    private final String senderProfileImageUrl;
+
+    @JsonProperty("message_type")
+    private final String messageType;
+
+    @JsonProperty("created_at")
+    private final LocalDateTime createdAt;
+
+    // --- TEXT ---
+    @JsonProperty("message_text_content")
+    private final String messageTextContent;
+
+    // --- IMAGE ---
+    @JsonProperty("message_image_url")
+    private final String messageImageUrl;
+
+    @JsonProperty("message_image_type")
+    private final String messageImageType;
+
+    @JsonProperty("message_image_name")
+    private final String messageImageName;
+
+    @JsonProperty("message_image_uuid")
+    private final String messageImageUuid;
+
+    // --- POST 공유 ---
+    @JsonProperty("post_id")
+    private final Long postId;
+
+    // --- STORY 공유 ---
+    // 명세서(Chat.pdf) 상 요청/응답 모두 "story_visitor_id"라는 필드명을 쓰지만 실제 DB 참조는 story_id
+    // 프론트와의 계약 유지를 위해 명세 그대로 따른다
+    @JsonProperty("story_visitor_id")
+    private final Long storyVisitorId;
+}

--- a/src/main/java/com/instagram/backend/domain/message/entity/MessageType.java
+++ b/src/main/java/com/instagram/backend/domain/message/entity/MessageType.java
@@ -1,0 +1,35 @@
+package com.instagram.backend.domain.message.entity;
+
+/*
+  MessageType — 메시지 타입 enum
+
+  설계 배경:
+    — Chat 도메인에서 "메시지 타입"이 여러 서비스(MessageService, ChatService)에 걸쳐 매직 스트링으로 존재했음
+    — 각 서비스가 별도로 private static final String으로 상수를 선언하면 오타·누락이 한쪽에서만 발생할 수 있음
+    — enum으로 통합해서 "TEXT/IMAGE/POST/STORY 외에는 존재할 수 없음"을 컴파일 타임에 보장
+
+  DB 컬럼 타입:
+    — Message 엔티티의 messageType 필드는 현재 String (DB 컬럼 message_type VARCHAR)
+    — 기존 데이터 호환을 위해 엔티티는 String 유지, 서비스 레이어에서 enum.name()으로 비교·저장
+    — 향후 @Enumerated(EnumType.STRING)으로 엔티티 필드를 enum으로 바꾸는 리팩토링 가능
+
+  isValid(String):
+    — 클라이언트가 보낸 dtype 문자열이 유효한 enum 값인지 검증할 때 사용
+    — 유효하지 않으면 ErrorCode.INVALID_DTYPE 던지는 용도
+*/
+public enum MessageType {
+    TEXT,
+    IMAGE,
+    POST,
+    STORY;
+
+    public static boolean isValid(String value) {
+        if (value == null) return false;
+        for (MessageType type : values()) {
+            if (type.name().equals(value)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/instagram/backend/domain/message/repository/MessageImageRepository.java
+++ b/src/main/java/com/instagram/backend/domain/message/repository/MessageImageRepository.java
@@ -1,0 +1,19 @@
+package com.instagram.backend.domain.message.repository;
+
+import com.instagram.backend.domain.message.entity.MessageImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Collection;
+import java.util.List;
+
+public interface MessageImageRepository extends JpaRepository<MessageImage, Long> {
+
+    /*
+      여러 메시지의 이미지 본문을 한 번에 조회 (IN 배치 조회)
+
+      목적: 메시지 목록 조회 시 IMAGE 타입 메시지의 부가 정보를 한 번에 가져오기 위함
+        — 각 메시지마다 따로 조회하면 N+1 발생
+        — SELECT * FROM message_images WHERE message_id IN (?, ?, ...)
+    */
+    List<MessageImage> findByMessageIdIn(Collection<Long> messageIds);
+}

--- a/src/main/java/com/instagram/backend/domain/message/repository/MessagePostRepository.java
+++ b/src/main/java/com/instagram/backend/domain/message/repository/MessagePostRepository.java
@@ -1,0 +1,16 @@
+package com.instagram.backend.domain.message.repository;
+
+import com.instagram.backend.domain.message.entity.MessagePost;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Collection;
+import java.util.List;
+
+public interface MessagePostRepository extends JpaRepository<MessagePost, Long> {
+
+    /*
+      여러 메시지의 공유 게시물 참조를 한 번에 조회 (IN 배치 조회)
+      목적: 메시지 목록 조회 시 POST 타입 메시지의 post_id를 한 번에 획득 (N+1 회피)
+    */
+    List<MessagePost> findByMessageIdIn(Collection<Long> messageIds);
+}

--- a/src/main/java/com/instagram/backend/domain/message/repository/MessageRepository.java
+++ b/src/main/java/com/instagram/backend/domain/message/repository/MessageRepository.java
@@ -1,8 +1,10 @@
 package com.instagram.backend.domain.message.repository;
 
 import com.instagram.backend.domain.message.entity.Message;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface MessageRepository extends JpaRepository<Message, Long> {
@@ -34,4 +36,27 @@ public interface MessageRepository extends JpaRepository<Message, Long> {
         — 서비스 레이어에서 null이면 0L로 변환해서 호출 (0보다 큰 모든 메시지 = 전체 카운트)
     */
     long countByChatRoomIdAndMessageIdGreaterThanAndIsDeletedFalse(Long chatRoomId, Long lastReadMessageId);
+
+    /*
+      채팅방 메시지 목록 — 초기 조회 (cursor 없음)
+
+      목적: GET /api/chats/{roomId}/messages 의 첫 페이지
+        — messageId DESC 정렬 → 가장 최신 메시지가 앞
+        — 프론트가 아래에서 위로 스크롤하면서 이전 메시지는 cursor로 추가 조회
+
+      Pageable:
+        — PageRequest.of(0, limit + 1) 로 "+1 트릭" 적용
+        — size보다 1개 더 가져와서 hasNext 판단 후 잘라냄
+    */
+    List<Message> findByChatRoomIdAndIsDeletedFalseOrderByMessageIdDesc(Long chatRoomId, Pageable pageable);
+
+    /*
+      채팅방 메시지 목록 — 커서 조회 (cursor 이전의 더 오래된 메시지)
+
+      동작: messageId < cursor 인 메시지들을 DESC로 조회
+        — cursor 값은 이전 응답의 next_cursor (그 페이지에서 가장 오래된 messageId)
+        — 반환되는 값들은 cursor보다 작은(= 더 과거의) 메시지들
+    */
+    List<Message> findByChatRoomIdAndIsDeletedFalseAndMessageIdLessThanOrderByMessageIdDesc(
+            Long chatRoomId, Long cursor, Pageable pageable);
 }

--- a/src/main/java/com/instagram/backend/domain/message/repository/MessageStoryRepository.java
+++ b/src/main/java/com/instagram/backend/domain/message/repository/MessageStoryRepository.java
@@ -1,0 +1,16 @@
+package com.instagram.backend.domain.message.repository;
+
+import com.instagram.backend.domain.message.entity.MessageStory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Collection;
+import java.util.List;
+
+public interface MessageStoryRepository extends JpaRepository<MessageStory, Long> {
+
+    /*
+      여러 메시지의 공유 스토리 참조를 한 번에 조회 (IN 배치 조회)
+      목적: 메시지 목록 조회 시 STORY 타입 메시지의 story_id를 한 번에 획득 (N+1 회피)
+    */
+    List<MessageStory> findByMessageIdIn(Collection<Long> messageIds);
+}

--- a/src/main/java/com/instagram/backend/domain/message/service/MessageService.java
+++ b/src/main/java/com/instagram/backend/domain/message/service/MessageService.java
@@ -1,0 +1,421 @@
+package com.instagram.backend.domain.message.service;
+
+import com.instagram.backend.domain.chat.repository.ChatRoomMemberRepository;
+import com.instagram.backend.domain.chat.repository.ChatRoomRepository;
+import com.instagram.backend.domain.member.entity.Member;
+import com.instagram.backend.domain.member.repository.MemberRepository;
+import com.instagram.backend.domain.message.dto.request.MessageSendRequest;
+import com.instagram.backend.domain.message.dto.response.MessageResponse;
+import com.instagram.backend.domain.message.entity.Message;
+import com.instagram.backend.domain.message.entity.MessageImage;
+import com.instagram.backend.domain.message.entity.MessagePost;
+import com.instagram.backend.domain.message.entity.MessageStory;
+import com.instagram.backend.domain.message.entity.MessageText;
+import com.instagram.backend.domain.message.entity.MessageType;
+import com.instagram.backend.domain.message.repository.MessageImageRepository;
+import com.instagram.backend.domain.message.repository.MessagePostRepository;
+import com.instagram.backend.domain.message.repository.MessageRepository;
+import com.instagram.backend.domain.message.repository.MessageStoryRepository;
+import com.instagram.backend.domain.message.repository.MessageTextRepository;
+import com.instagram.backend.domain.post.entity.Post;
+import com.instagram.backend.domain.post.repository.PostRepository;
+import com.instagram.backend.domain.story.entity.Story;
+import com.instagram.backend.domain.story.repository.StoryRepository;
+import com.instagram.backend.global.dto.CursorPageResponse;
+import com.instagram.backend.global.exception.BusinessException;
+import com.instagram.backend.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/*
+  MessageService — 채팅방 메시지 도메인 비즈니스 로직
+
+  담당 기능 (이슈 A단계):
+    1) sendMessage    — POST /api/chats/{roomId}/messages
+    2) getMessages    — GET  /api/chats/{roomId}/messages (커서 페이지네이션)
+
+  설계 원칙:
+    — 매직 스트링 대신 MessageType enum 사용 (ChatService와 상수 공유)
+    — 방 존재 + 참여자 권한 검증은 private helper로 통합 (sendMessage/getMessages 중복 제거)
+    — N+1 회피: 목록 조회에서 서브 테이블(Text/Image/Post/Story) + Member를 IN 배치 조회
+    — 소프트 삭제 패턴: 탈퇴/삭제된 리소스는 자동 제외
+
+  @Transactional(readOnly = true) 클래스 레벨:
+    — 기본은 읽기 전용 (조회 성능 최적화)
+    — 쓰기 메서드는 @Transactional 로 덮어씀
+*/
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MessageService {
+
+    // 목록 조회 limit 기본값/최대값 (명세서: 기본 30)
+    // 상한 100은 서버 정책 — 명세 원본에 없으므로 향후 API 문서 업데이트 필요
+    private static final int DEFAULT_LIMIT = 30;
+    private static final int MAX_LIMIT = 100;
+
+    private final MessageRepository messageRepository;
+    private final MessageTextRepository messageTextRepository;
+    private final MessageImageRepository messageImageRepository;
+    private final MessagePostRepository messagePostRepository;
+    private final MessageStoryRepository messageStoryRepository;
+
+    private final ChatRoomRepository chatRoomRepository;
+    private final ChatRoomMemberRepository chatRoomMemberRepository;
+    private final MemberRepository memberRepository;
+    private final PostRepository postRepository;
+    private final StoryRepository storyRepository;
+
+    /*
+      메시지 전송 — POST /api/chats/{roomId}/messages
+
+      처리 순서:
+        1) 방 존재 + 참여자 검증 (공통 helper)
+        2) dtype 검증 (400 MISSING_REQUIRED_FIELD / INVALID_DTYPE)
+        3) dtype별 필수 필드 검증 (400 MISSING_MESSAGE_CONTENT)
+        4) 공유 대상 존재 검증 (POST/STORY일 때 404)
+        5) Message 공통 레코드 저장
+        6) dtype에 대응하는 서브 테이블 레코드 저장
+        7) 작성자 정보(소프트 삭제 제외) 조회 후 응답 DTO 반환
+
+      트랜잭션 원자성:
+        — @Transactional 덮어쓰기로 공통 Message + 서브 테이블 저장이 한 트랜잭션에서 처리
+        — 중간에 RuntimeException이 터지면 둘 다 롤백 (고아 row 방지)
+
+      TODO(#블록도메인 이슈): POST/STORY 공유 시 BLOCKED_MEMBER 검증 추가
+    */
+    @Transactional
+    public MessageResponse sendMessage(Long myMemberId, Long roomId, MessageSendRequest request) {
+        // 1) 방 존재 + 참여자 검증
+        validateRoomAndParticipant(roomId, myMemberId);
+
+        // 2) dtype 존재/유효성 검증
+        String rawDtype = request.getDtype();
+        if (rawDtype == null || rawDtype.isBlank()) {
+            throw new BusinessException(ErrorCode.MISSING_REQUIRED_FIELD);
+        }
+        if (!MessageType.isValid(rawDtype)) {
+            throw new BusinessException(ErrorCode.INVALID_DTYPE);
+        }
+        MessageType dtype = MessageType.valueOf(rawDtype);
+
+        // 3) dtype별 필수 필드 검증 + 4) 공유 대상 존재 검증
+        //    저장 실패 시 공통 Message까지 롤백되도록 한 트랜잭션 내에서 처리
+        Post sharedPost = null;
+        Story sharedStory = null;
+        switch (dtype) {
+            case TEXT -> {
+                if (request.getMessageTextContent() == null || request.getMessageTextContent().isBlank()) {
+                    throw new BusinessException(ErrorCode.MISSING_MESSAGE_CONTENT);
+                }
+            }
+            case IMAGE -> {
+                if (request.getMessageImageUrl() == null || request.getMessageImageUrl().isBlank()) {
+                    throw new BusinessException(ErrorCode.MISSING_MESSAGE_CONTENT);
+                }
+            }
+            case POST -> {
+                if (request.getPostId() == null) {
+                    throw new BusinessException(ErrorCode.MISSING_MESSAGE_CONTENT);
+                }
+                sharedPost = postRepository.findByPostIdAndIsDeletedFalse(request.getPostId())
+                        .orElseThrow(() -> new BusinessException(ErrorCode.POST_NOT_FOUND));
+            }
+            case STORY -> {
+                if (request.getStoryVisitorId() == null) {
+                    throw new BusinessException(ErrorCode.MISSING_MESSAGE_CONTENT);
+                }
+                // 명세서 상 "story_visitor_id"라는 이름을 쓰지만 실제 DB 참조는 story_id
+                sharedStory = storyRepository.findByStoryIdAndIsDeletedFalse(request.getStoryVisitorId())
+                        .orElseThrow(() -> new BusinessException(ErrorCode.STORY_NOT_FOUND));
+            }
+            // default는 isValid 검증 이후라 도달 불가. 향후 enum 확장 시 안전장치
+            default -> throw new BusinessException(ErrorCode.INVALID_DTYPE);
+        }
+
+        // 5) 공통 Message 저장 — 먼저 messageId를 확보해야 서브 테이블 FK에 넣을 수 있음
+        Message message = Message.builder()
+                .memberId(myMemberId)
+                .chatRoomId(roomId)
+                .messageType(dtype.name())
+                .build();
+        Message savedMessage = messageRepository.save(message);
+
+        // 6) dtype별 서브 테이블 저장
+        switch (dtype) {
+            case TEXT -> messageTextRepository.save(MessageText.builder()
+                    .messageId(savedMessage.getMessageId())
+                    .messageTextContents(request.getMessageTextContent())
+                    .build());
+            case IMAGE -> messageImageRepository.save(MessageImage.builder()
+                    .messageId(savedMessage.getMessageId())
+                    .imageUrl(request.getMessageImageUrl())
+                    .imageType(request.getMessageImageType())
+                    .imageName(request.getMessageImageName())
+                    .imageUuid(request.getMessageImageUuid())
+                    .build());
+            case POST -> messagePostRepository.save(MessagePost.builder()
+                    .messageId(savedMessage.getMessageId())
+                    .postId(sharedPost.getPostId())
+                    .build());
+            case STORY -> messageStoryRepository.save(MessageStory.builder()
+                    .messageId(savedMessage.getMessageId())
+                    .storyId(sharedStory.getStoryId())
+                    .build());
+            default -> throw new BusinessException(ErrorCode.INVALID_DTYPE);
+        }
+
+        // 7) 작성자 정보 조회 (소프트 삭제 제외)
+        //    — findById(Long)은 탈퇴 계정까지 노출하므로 프로젝트 전반의 isDeletedFalse 패턴 사용
+        Member sender = memberRepository.findByMemberIdAndIsDeletedFalse(myMemberId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+
+        return buildSendResponse(savedMessage, sender, dtype, request, sharedPost, sharedStory);
+    }
+
+    /*
+      메시지 목록 조회 — GET /api/chats/{roomId}/messages
+
+      커서 페이지네이션 규칙:
+        — cursor가 null이면 가장 최신 limit개
+        — cursor가 있으면 messageId < cursor 조건으로 더 오래된 limit개
+        — 정렬은 messageId DESC (최신이 앞)
+        — next_cursor는 이 페이지에서 가장 오래된 messageId (다음 요청에 그대로 넣음)
+        — has_next 판단: "+1 트릭" — size+1 개 가져온 뒤 1개 더 있으면 있음
+
+      N+1 회피:
+        — 메시지 목록 확보 후 한 번씩만 IN 배치 조회
+          (message_texts, message_images, message_posts, message_stories)
+        — 작성자 정보도 IN 배치 조회
+
+      탈퇴한 sender 정책:
+        — findByMemberIdInAndIsDeletedFalse는 탈퇴 계정을 결과에 포함하지 않음
+        — 이 경우 응답의 sender_username/profile_image_url이 null로 내려감
+        — 프론트는 null일 때 "(알 수 없음)" 등으로 렌더링 (정책 주석)
+    */
+    public CursorPageResponse<MessageResponse> getMessages(Long myMemberId, Long roomId, String cursor, Integer limit) {
+        // 1) 방 존재 + 참여자 검증
+        validateRoomAndParticipant(roomId, myMemberId);
+
+        // 2) limit 정규화 + 검증
+        int size = (limit == null) ? DEFAULT_LIMIT : limit;
+        if (size < 1 || size > MAX_LIMIT) {
+            throw new BusinessException(ErrorCode.INVALID_LIMIT);
+        }
+
+        // 3) cursor 파싱 — 숫자 형식/양수 검증
+        Long cursorId = parseCursor(cursor);
+
+        // 4) 메시지 조회 (+1 트릭으로 hasNext 판단)
+        Pageable pageable = PageRequest.of(0, size + 1);
+        List<Message> fetched = (cursorId == null)
+                ? messageRepository.findByChatRoomIdAndIsDeletedFalseOrderByMessageIdDesc(roomId, pageable)
+                : messageRepository.findByChatRoomIdAndIsDeletedFalseAndMessageIdLessThanOrderByMessageIdDesc(roomId, cursorId, pageable);
+
+        boolean hasNext = fetched.size() > size;
+        List<Message> messages = hasNext ? fetched.subList(0, size) : fetched;
+
+        if (messages.isEmpty()) {
+            // 빈 페이지는 next_cursor/hasNext 모두 없음 — 명시적 분기로 가독성 확보
+            return CursorPageResponse.of(Collections.emptyList(), null, false);
+        }
+
+        // 5) 각 서브 테이블 IN 배치 조회
+        List<Long> textIds = new ArrayList<>();
+        List<Long> imageIds = new ArrayList<>();
+        List<Long> postIds = new ArrayList<>();
+        List<Long> storyIds = new ArrayList<>();
+        Set<Long> senderIds = new HashSet<>();
+
+        for (Message m : messages) {
+            senderIds.add(m.getMemberId());
+            String typeStr = m.getMessageType();
+            if (!MessageType.isValid(typeStr)) {
+                continue; // 데이터 무결성 깨진 row는 건너뛰기
+            }
+            switch (MessageType.valueOf(typeStr)) {
+                case TEXT -> textIds.add(m.getMessageId());
+                case IMAGE -> imageIds.add(m.getMessageId());
+                case POST -> postIds.add(m.getMessageId());
+                case STORY -> storyIds.add(m.getMessageId());
+            }
+        }
+
+        Map<Long, MessageText> textMap = new HashMap<>();
+        Map<Long, MessageImage> imageMap = new HashMap<>();
+        Map<Long, MessagePost> postMap = new HashMap<>();
+        Map<Long, MessageStory> storyMap = new HashMap<>();
+
+        if (!textIds.isEmpty()) {
+            for (MessageText t : messageTextRepository.findByMessageIdIn(textIds)) {
+                textMap.put(t.getMessageId(), t);
+            }
+        }
+        if (!imageIds.isEmpty()) {
+            for (MessageImage i : messageImageRepository.findByMessageIdIn(imageIds)) {
+                imageMap.put(i.getMessageId(), i);
+            }
+        }
+        if (!postIds.isEmpty()) {
+            for (MessagePost p : messagePostRepository.findByMessageIdIn(postIds)) {
+                postMap.put(p.getMessageId(), p);
+            }
+        }
+        if (!storyIds.isEmpty()) {
+            for (MessageStory s : messageStoryRepository.findByMessageIdIn(storyIds)) {
+                storyMap.put(s.getMessageId(), s);
+            }
+        }
+
+        // 작성자 일괄 조회 (N+1 회피 + 소프트 삭제 제외)
+        Map<Long, Member> senderMap = new HashMap<>();
+        for (Member m : memberRepository.findByMemberIdInAndIsDeletedFalse(senderIds)) {
+            senderMap.put(m.getMemberId(), m);
+        }
+
+        // 6) 응답 조립
+        List<MessageResponse> content = new ArrayList<>();
+        for (Message m : messages) {
+            content.add(buildListItem(m, senderMap, textMap, imageMap, postMap, storyMap));
+        }
+
+        // 7) next_cursor = 이번 페이지의 가장 오래된(= 마지막 원소) messageId
+        //    messages는 DESC 정렬이므로 마지막이 가장 작은 값
+        String nextCursor = hasNext
+                ? String.valueOf(messages.get(messages.size() - 1).getMessageId())
+                : null;
+
+        return CursorPageResponse.of(content, nextCursor, hasNext);
+    }
+
+    // ===== private helpers =====
+
+    /*
+      방 존재 여부 + 참여자 권한 검증 (공통 helper)
+
+      sendMessage / getMessages 모두 동일한 검증이 필요하므로 추출.
+      existsByChatRoomIdAndMemberId는 count(*) LIMIT 1 쿼리로 번역되어
+      전체 row를 JVM에 끌어오는 것보다 훨씬 효율적.
+    */
+    private void validateRoomAndParticipant(Long roomId, Long memberId) {
+        chatRoomRepository.findByChatRoomIdAndIsDeletedFalse(roomId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ROOM_NOT_FOUND));
+        if (!chatRoomMemberRepository.existsByChatRoomIdAndMemberId(roomId, memberId)) {
+            throw new BusinessException(ErrorCode.CHAT_ROOM_FORBIDDEN);
+        }
+    }
+
+    /*
+      cursor 문자열 파싱
+
+      - null/공백 → null (초기 조회)
+      - 숫자 형식 아님 → INVALID_CURSOR
+      - 0 이하 → INVALID_CURSOR (messageId는 1부터 시작)
+    */
+    private Long parseCursor(String cursor) {
+        if (cursor == null || cursor.isBlank()) {
+            return null;
+        }
+        try {
+            long parsed = Long.parseLong(cursor);
+            if (parsed <= 0) {
+                throw new BusinessException(ErrorCode.INVALID_CURSOR);
+            }
+            return parsed;
+        } catch (NumberFormatException e) {
+            throw new BusinessException(ErrorCode.INVALID_CURSOR);
+        }
+    }
+
+    /*
+      메시지 전송 응답 DTO 조립
+      전송 API에서 방금 저장한 값들을 그대로 DTO에 매핑한다.
+    */
+    private MessageResponse buildSendResponse(Message savedMessage,
+                                              Member sender,
+                                              MessageType dtype,
+                                              MessageSendRequest request,
+                                              Post sharedPost,
+                                              Story sharedStory) {
+        return MessageResponse.builder()
+                .messageId(savedMessage.getMessageId())
+                .chatRoomId(savedMessage.getChatRoomId())
+                .senderId(sender.getMemberId())
+                .senderUsername(sender.getMemberUsername())
+                .senderProfileImageUrl(sender.getImageUrl())
+                .messageType(savedMessage.getMessageType())
+                .createdAt(savedMessage.getCreatedAt())
+                .messageTextContent(dtype == MessageType.TEXT ? request.getMessageTextContent() : null)
+                .messageImageUrl(dtype == MessageType.IMAGE ? request.getMessageImageUrl() : null)
+                .messageImageType(dtype == MessageType.IMAGE ? request.getMessageImageType() : null)
+                .messageImageName(dtype == MessageType.IMAGE ? request.getMessageImageName() : null)
+                .messageImageUuid(dtype == MessageType.IMAGE ? request.getMessageImageUuid() : null)
+                .postId(dtype == MessageType.POST ? sharedPost.getPostId() : null)
+                .storyVisitorId(dtype == MessageType.STORY ? sharedStory.getStoryId() : null)
+                .build();
+    }
+
+    /*
+      메시지 목록 응답 DTO 조립
+      각 메시지에 대해 작성자 정보와 서브 테이블 정보를 조립한다.
+      탈퇴 계정(senderMap에 없음)은 username/imageUrl을 null로 내린다.
+    */
+    private MessageResponse buildListItem(Message m,
+                                          Map<Long, Member> senderMap,
+                                          Map<Long, MessageText> textMap,
+                                          Map<Long, MessageImage> imageMap,
+                                          Map<Long, MessagePost> postMap,
+                                          Map<Long, MessageStory> storyMap) {
+        Member sender = senderMap.get(m.getMemberId());
+        MessageResponse.MessageResponseBuilder b = MessageResponse.builder()
+                .messageId(m.getMessageId())
+                .chatRoomId(m.getChatRoomId())
+                .senderId(m.getMemberId())
+                .senderUsername(sender != null ? sender.getMemberUsername() : null)
+                .senderProfileImageUrl(sender != null ? sender.getImageUrl() : null)
+                .messageType(m.getMessageType())
+                .createdAt(m.getCreatedAt());
+
+        if (!MessageType.isValid(m.getMessageType())) {
+            return b.build(); // 데이터 무결성 깨진 row — 공통 필드만
+        }
+        switch (MessageType.valueOf(m.getMessageType())) {
+            case TEXT -> {
+                MessageText t = textMap.get(m.getMessageId());
+                if (t != null) b.messageTextContent(t.getMessageTextContents());
+            }
+            case IMAGE -> {
+                MessageImage i = imageMap.get(m.getMessageId());
+                if (i != null) {
+                    b.messageImageUrl(i.getImageUrl())
+                     .messageImageType(i.getImageType())
+                     .messageImageName(i.getImageName())
+                     .messageImageUuid(i.getImageUuid());
+                }
+            }
+            case POST -> {
+                MessagePost p = postMap.get(m.getMessageId());
+                if (p != null) b.postId(p.getPostId());
+            }
+            case STORY -> {
+                MessageStory s = storyMap.get(m.getMessageId());
+                if (s != null) b.storyVisitorId(s.getStoryId());
+            }
+            default -> {
+                // 도달 불가 — 위 isValid 검사로 걸러짐
+            }
+        }
+        return b.build();
+    }
+}

--- a/src/main/java/com/instagram/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/instagram/backend/global/exception/ErrorCode.java
@@ -11,7 +11,8 @@ public enum ErrorCode {
     EXCEED_IMAGE_LIMIT(400, "이미지는 최대 10개까지 첨부 가능합니다."),
     EXCEED_CONTENT_LENGTH(400, "게시물 내용은 2200자 이내로 입력해주세요."),
     INVALID_TAG_USERNAME(400, "태그한 사용자를 찾을 수 없습니다."),
-    INVALID_LIMIT(400, "limit 값이 올바르지 않습니다. (1~30)"),
+    INVALID_LIMIT(400, "limit 값이 올바르지 않습니다."),
+    INVALID_CURSOR(400, "cursor 값이 올바르지 않습니다."),
     INVALID_EMAIL_FORMAT(400, "이메일 형식이 올바르지 않습니다."),
     INVALID_PASSWORD_FORMAT(400, "비밀번호는 8자 이상이어야 합니다."),
     INVALID_USERNAME_FORMAT(400, "유저네임은 영문, 숫자, _만 사용 가능합니다."),
@@ -20,6 +21,8 @@ public enum ErrorCode {
     INVALID_GENDER_VALUE(400, "성별 값이 올바르지 않습니다. (MALE/FEMALE/OTHER)"),
     INVALID_IMAGE_TYPE(400, "지원하지 않는 이미지 형식입니다."),
     EXCEED_COMMENT_LENGTH(400, "댓글 내용은 500자 이내로 입력해주세요."),
+    INVALID_DTYPE(400, "올바르지 않은 메시지 타입입니다."),
+    MISSING_MESSAGE_CONTENT(400, "메시지 내용을 입력해주세요."),
 
     // 401 - 인증 오류
     UNAUTHORIZED(401, "로그인이 필요합니다."),
@@ -34,6 +37,7 @@ public enum ErrorCode {
     BLOCKED_MEMBER(403, "차단된 사용자의 스토리입니다."),
     COMMENT_DISABLED(403, "댓글이 허용되지 않는 게시물입니다."),
     COMMENT_FORBIDDEN(403, "댓글 작성자 또는 게시물 주인만 삭제할 수 있습니다."),
+    CHAT_ROOM_FORBIDDEN(403, "해당 채팅방에 접근 권한이 없습니다."),
 
     CANNOT_FOLLOW_SELF(400, "자기 자신을 팔로우할 수 없습니다."),
     SELF_CHAT_NOT_ALLOWED(400, "자기 자신과 채팅방을 만들 수 없습니다."),


### PR DESCRIPTION
  - POST /api/chats/{roomId}/messages — TEXT/IMAGE/POST/STORY 4종 dtype 분기
  - GET  /api/chats/{roomId}/messages — 커서 페이지네이션 (기본 limit 30, 최대 100)
  - MessageType enum 신설 — ChatService/MessageService의 매직 스트링 중복 제거
  - 참여자 검증은 ChatRoomMemberRepository.existsByChatRoomIdAndMemberId로 통합
  - MessageImage/Post/Story Repository 신규 + MessageRepository에 커서용 메서드 추가
  - MemberRepository.findByMemberIdAndIsDeletedFalse 추가 (소프트 삭제 일관성 확보)
  - ErrorCode에 INVALID_DTYPE, MISSING_MESSAGE_CONTENT, CHAT_ROOM_FORBIDDEN, INVALID_CURSOR 추가
  - N+1 회피: 목록 조회 시 서브 테이블/작성자 전부 IN 배치 조회
  - 코드 리뷰 피드백 반영 (CRITICAL 1 + HIGH 4 + MEDIUM 2)

  closes #38