### PR TITLE
refactor: Post 도메인 코드 품질 개선 (#11)

### DIFF
--- a/src/main/java/com/instagram/backend/domain/post/controller/PostController.java
+++ b/src/main/java/com/instagram/backend/domain/post/controller/PostController.java
@@ -15,6 +15,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import jakarta.validation.Valid;
+
 @RestController
 @RequestMapping("/api/posts")
 @RequiredArgsConstructor
@@ -38,7 +40,7 @@ public class PostController {
     @PostMapping
     public ResponseEntity<ApiResponse<PostCreateResponse>> createPost(
             @AuthenticationPrincipal CustomUserDetails userDetails,
-            @RequestBody PostCreateRequest request) {
+            @Valid @RequestBody PostCreateRequest request) {
         return ResponseEntity.status(HttpStatus.CREATED).body(
                 ApiResponse.success(postService.createPost(userDetails.getMemberId(), request), "게시물이 등록되었습니다.")
         );
@@ -49,7 +51,7 @@ public class PostController {
     public ResponseEntity<ApiResponse<Void>> updatePost(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable Long postId,
-            @RequestBody PostUpdateRequest request) {
+            @Valid @RequestBody PostUpdateRequest request) {
         postService.updatePost(userDetails.getMemberId(), postId, request);
         return ResponseEntity.ok(
                 ApiResponse.success(null, "게시물이 수정되었습니다.")

--- a/src/main/java/com/instagram/backend/domain/post/dto/PostCreateRequest.java
+++ b/src/main/java/com/instagram/backend/domain/post/dto/PostCreateRequest.java
@@ -1,6 +1,7 @@
 package com.instagram.backend.domain.post.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -9,6 +10,7 @@ import java.util.List;
 @Getter
 @NoArgsConstructor
 public class PostCreateRequest {
+    @Size(max = 2200)
     @JsonProperty("post_contents")
     private String postContents;
 

--- a/src/main/java/com/instagram/backend/domain/post/dto/PostUpdateRequest.java
+++ b/src/main/java/com/instagram/backend/domain/post/dto/PostUpdateRequest.java
@@ -1,6 +1,7 @@
 package com.instagram.backend.domain.post.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -8,6 +9,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class PostUpdateRequest {
 
+    @Size(max = 2200)
     @JsonProperty("post_contents")
     private String postContents;
 

--- a/src/main/java/com/instagram/backend/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/instagram/backend/domain/post/repository/PostRepository.java
@@ -2,6 +2,8 @@ package com.instagram.backend.domain.post.repository;
 
 import com.instagram.backend.domain.post.entity.Post;
 import org.springframework.data.jpa.repository.JpaRepository;// Spring Data JPA 기능 SQL을 짜지 않아도 기본적인 CRUD 자동 생성
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Collection;
 import java.util.List;
@@ -9,6 +11,10 @@ import java.util.Optional;
 
 public interface PostRepository extends JpaRepository<Post, Long> {//<다룰 앤티티,PK 타입> => save(), findAll(), delete() 바로 가져다 쓸 수 있
     Optional<Post> findByPostIdAndIsDeletedFalse(Long postId);
+
+    // member를 JOIN FETCH로 함께 조회하여 N+1 방지
+    @Query("SELECT p FROM Post p JOIN FETCH p.member WHERE p.postId = :postId AND p.isDeleted = false")
+    Optional<Post> findByPostIdWithMemberAndIsDeletedFalse(@Param("postId") Long postId);
 
     // SELECT * FROM posts WHERE post_id IN (?, ?, ...) AND is_deleted = false
     // — 여러 post_id를 한 번의 쿼리로 조회 (N+1 문제 회피)

--- a/src/main/java/com/instagram/backend/domain/post/service/PostService.java
+++ b/src/main/java/com/instagram/backend/domain/post/service/PostService.java
@@ -93,11 +93,7 @@ public class PostService {
         Post post = postRepository.findByPostIdAndIsDeletedFalse(postId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.POST_NOT_FOUND));
 
-        // 본인 게시물인지 확인
-        if (!post.getMember().getMemberId().equals(memberId)) {
-            throw new BusinessException(ErrorCode.FORBIDDEN);
-        }
-
+        validatePostOwner(post, memberId);
         post.update(request.getPostContents(), request.isCommentEnabled());
     }
 
@@ -107,11 +103,13 @@ public class PostService {
         Post post = postRepository.findByPostIdAndIsDeletedFalse(postId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.POST_NOT_FOUND));
 
-        // 본인 게시물인지 확인
+        validatePostOwner(post, memberId);
+        post.softDelete();
+    }
+
+    private void validatePostOwner(Post post, Long memberId) {
         if (!post.getMember().getMemberId().equals(memberId)) {
             throw new BusinessException(ErrorCode.FORBIDDEN);
         }
-
-        post.softDelete();
     }
 }

--- a/src/main/java/com/instagram/backend/domain/post/service/PostService.java
+++ b/src/main/java/com/instagram/backend/domain/post/service/PostService.java
@@ -36,7 +36,7 @@ public class PostService {
 
     // 게시물 단건 조회
     public PostResponse getPost(Long memberId, Long postId) {
-        Post post = postRepository.findByPostIdAndIsDeletedFalse(postId)
+        Post post = postRepository.findByPostIdWithMemberAndIsDeletedFalse(postId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.POST_NOT_FOUND));
 
         List<PostImage> images = postImageRepository.findByPostPostIdOrderBySortOrderAsc(postId);
@@ -92,7 +92,7 @@ public class PostService {
     // 게시물 수정
     @Transactional
     public void updatePost(Long memberId, Long postId, PostUpdateRequest request) {
-        Post post = postRepository.findByPostIdAndIsDeletedFalse(postId)
+        Post post = postRepository.findByPostIdWithMemberAndIsDeletedFalse(postId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.POST_NOT_FOUND));
 
         validatePostOwner(post, memberId);
@@ -102,7 +102,7 @@ public class PostService {
     // 게시물 삭제 (소프트 딜리트)
     @Transactional
     public void deletePost(Long memberId, Long postId) {
-        Post post = postRepository.findByPostIdAndIsDeletedFalse(postId)
+        Post post = postRepository.findByPostIdWithMemberAndIsDeletedFalse(postId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.POST_NOT_FOUND));
 
         validatePostOwner(post, memberId);

--- a/src/main/java/com/instagram/backend/domain/post/service/PostService.java
+++ b/src/main/java/com/instagram/backend/domain/post/service/PostService.java
@@ -19,6 +19,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -70,9 +71,10 @@ public class PostService {
         postRepository.save(post);
 
         // 이미지 저장
+        List<PostImage> images = new ArrayList<>();
         for (int i = 0; i < request.getImages().size(); i++) {
             var imageReq = request.getImages().get(i);
-            PostImage postImage = PostImage.builder()
+            images.add(PostImage.builder()
                     .post(post)
                     .imageUrl(imageReq.getPostImageUrl())
                     .imageType(imageReq.getPostImageType())
@@ -80,9 +82,9 @@ public class PostService {
                     .imageUuid(imageReq.getPostImageUuid())
                     .altText(imageReq.getPostImageAltText())
                     .sortOrder(i)
-                    .build();
-            postImageRepository.save(postImage);
+                    .build());
         }
+        postImageRepository.saveAll(images);
 
         return PostCreateResponse.from(post);
     }

--- a/src/main/java/com/instagram/backend/domain/post/service/PostService.java
+++ b/src/main/java/com/instagram/backend/domain/post/service/PostService.java
@@ -57,10 +57,6 @@ public class PostService {
         if (request.getImages().size() > 10) {
             throw new BusinessException(ErrorCode.EXCEED_IMAGE_LIMIT);
         }
-        // 내용 2200자 초과 검증
-        if (request.getPostContents() != null && request.getPostContents().length() > 2200) {
-            throw new BusinessException(ErrorCode.EXCEED_CONTENT_LENGTH);
-        }
 
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
@@ -94,11 +90,6 @@ public class PostService {
     // 게시물 수정
     @Transactional
     public void updatePost(Long memberId, Long postId, PostUpdateRequest request) {
-        // 내용 2200자 초과 검증
-        if (request.getPostContents() != null && request.getPostContents().length() > 2200) {
-            throw new BusinessException(ErrorCode.EXCEED_CONTENT_LENGTH);
-        }
-
         Post post = postRepository.findByPostIdAndIsDeletedFalse(postId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.POST_NOT_FOUND));
 

--- a/src/main/java/com/instagram/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/instagram/backend/global/exception/GlobalExceptionHandler.java
@@ -42,7 +42,11 @@ public class GlobalExceptionHandler {
         if (annotationCode == null) return ErrorCode.MISSING_REQUIRED_FIELD.name();
         return switch (annotationCode) {
             case "Email" -> ErrorCode.INVALID_EMAIL_FORMAT.name();
-            case "Size", "Min" -> field.contains("assword") ? ErrorCode.INVALID_PASSWORD_FORMAT.name() : ErrorCode.MISSING_REQUIRED_FIELD.name();
+            case "Size", "Min" -> {
+                if (field.contains("assword")) yield ErrorCode.INVALID_PASSWORD_FORMAT.name();
+                if (field.contains("ontents")) yield ErrorCode.EXCEED_CONTENT_LENGTH.name();
+                yield ErrorCode.MISSING_REQUIRED_FIELD.name();
+            }
             case "Pattern" -> field.contains("sername") ? ErrorCode.INVALID_USERNAME_FORMAT.name() : ErrorCode.MISSING_REQUIRED_FIELD.name();
             default -> ErrorCode.MISSING_REQUIRED_FIELD.name();
         };


### PR DESCRIPTION
## 개요
Post 도메인의 유효성 검증 누락, 중복 코드, 성능 문제를 통합 수정합니다.

Closes #11

---

## 변경 사항

### 1. `@Valid` 누락 수정
- `createPost()`, `updatePost()` 파라미터에 `@Valid` 추가
- 기존에는 DTO에 검증 어노테이션을 달아도 실제로 동작하지 않는 상태였음

### 2. 게시물 내용 길이 검증 중복 제거
- `PostCreateRequest`, `PostUpdateRequest` DTO에 `@Size(max = 2200)` 추가
- `PostService`의 `createPost()`, `updatePost()` 양쪽에 있던 중복 검증 블록 제거
- `GlobalExceptionHandler`에 `postContents` 필드 `@Size` 위반 시 `EXCEED_CONTENT_LENGTH` 매핑 추가
  - 기존 핸들러는 `Size` 위반을 `password` 필드만 처리했기 때문에 `postContents`는 `MISSING_REQUIRED_FIELD`가 반환되는 문제가 있었음

### 3. 소유자 검증 로직 중복 제거
- `updatePost()`, `deletePost()` 양쪽에 동일하게 존재하던 소유자 검증 코드를 `validatePostOwner()` private 헬퍼 메서드로 추출

### 4. 이미지 저장 최적화 (`saveAll`)
- 루프 내 `postImageRepository.save()` 개별 호출 → 리스트 빌드 후 `postImageRepository.saveAll()` 한 번 호출로 변경
- 이미지 최대 10개 기준 최대 10번이던 INSERT 호출 횟수 감소

### 5. Post 조회 N+1 해결
- `PostRepository`에 `findByPostIdWithMemberAndIsDeletedFalse()` 추가 (`JOIN FETCH p.member`)
- `getPost()`, `updatePost()`, `deletePost()` 3곳에서 새 메서드로 교체
- 기존: Post 조회 후 `post.getMember()` 접근 시 LAZY 로딩으로 추가 쿼리 발생 (총 2번)
- 개선: JOIN FETCH로 Post + Member 한 번에 조회 (총 1번)

---

## 수정 파일
| 파일 | 변경 내용 |
|------|----------|
| `PostController.java` | `@Valid` 추가 |
| `PostCreateRequest.java` | `@Size(max = 2200)` 추가 |
| `PostUpdateRequest.java` | `@Size(max = 2200)` 추가 |
| `PostService.java` | 검증 코드 제거, 헬퍼 메서드 추출, `saveAll` 교체, 메서드 교체 |
| `PostRepository.java` | JOIN FETCH 메서드 추가 |
| `GlobalExceptionHandler.java` | `postContents` Size 위반 매핑 추가 |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 게시물 콘텐츠 최대 길이(2200자) 검증 강화

* **버그 수정**
  * 입력값 검증 오류에 대한 명확한 에러 메시지 제공
  * 게시물 소유권 확인 로직 안정화

* **성능 개선**
  * 게시물 조회 및 관리 작업 성능 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->