### PR TITLE
45 feat hashtagapi

### DIFF
--- a/src/main/java/com/instagram/backend/domain/hashtag/controller/HashtagController.java
+++ b/src/main/java/com/instagram/backend/domain/hashtag/controller/HashtagController.java
@@ -1,0 +1,28 @@
+package com.instagram.backend.domain.hashtag.controller;
+
+import com.instagram.backend.domain.hashtag.dto.response.HashtagResponse;
+import com.instagram.backend.domain.hashtag.service.HashtagService;
+import com.instagram.backend.global.dto.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/hashtags")
+public class HashtagController {
+
+    private final HashtagService hashtagService;
+
+    // 해시태그 단건 조회 — GET /api/hashtags/{name}
+    @GetMapping("/{name}")
+    public ResponseEntity<ApiResponse<HashtagResponse>> getHashtag(
+            @PathVariable String name) {
+        return ResponseEntity.ok(
+                ApiResponse.success(hashtagService.getHashtag(name), "해시태그 조회 성공")
+        );
+    }
+}

--- a/src/main/java/com/instagram/backend/domain/hashtag/controller/HashtagController.java
+++ b/src/main/java/com/instagram/backend/domain/hashtag/controller/HashtagController.java
@@ -1,14 +1,14 @@
 package com.instagram.backend.domain.hashtag.controller;
 
 import com.instagram.backend.domain.hashtag.dto.response.HashtagResponse;
+import com.instagram.backend.domain.hashtag.service.HashtagFollowService;
 import com.instagram.backend.domain.hashtag.service.HashtagService;
 import com.instagram.backend.global.dto.ApiResponse;
+import com.instagram.backend.global.security.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class HashtagController {
 
     private final HashtagService hashtagService;
+    private final HashtagFollowService hashtagFollowService;
 
     // 해시태그 단건 조회 — GET /api/hashtags/{name}
     @GetMapping("/{name}")
@@ -24,5 +25,21 @@ public class HashtagController {
         return ResponseEntity.ok(
                 ApiResponse.success(hashtagService.getHashtag(name), "해시태그 조회 성공")
         );
+    }
+    @PostMapping("/{hashtagId}/follow")
+    public ResponseEntity<ApiResponse<Void>> followHashtag(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long hashtagId) {
+        hashtagFollowService.followHashtag(userDetails.getMemberId(), hashtagId);
+        return ResponseEntity.ok(ApiResponse.success(null, "해시태그 팔로우 완료"));
+    }
+
+    // 해시태그 언팔로우 — DELETE /api/hashtags/{hashtagId}/follow
+    @DeleteMapping("/{hashtagId}/follow")
+    public ResponseEntity<ApiResponse<Void>> unfollowHashtag(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long hashtagId) {
+        hashtagFollowService.unfollowHashtag(userDetails.getMemberId(), hashtagId);
+        return ResponseEntity.ok(ApiResponse.success(null, "해시태그 언팔로우 완료"));
     }
 }

--- a/src/main/java/com/instagram/backend/domain/hashtag/controller/HashtagController.java
+++ b/src/main/java/com/instagram/backend/domain/hashtag/controller/HashtagController.java
@@ -6,6 +6,7 @@ import com.instagram.backend.domain.hashtag.service.HashtagService;
 import com.instagram.backend.global.dto.ApiResponse;
 import com.instagram.backend.global.security.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -31,7 +32,8 @@ public class HashtagController {
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable Long hashtagId) {
         hashtagFollowService.followHashtag(userDetails.getMemberId(), hashtagId);
-        return ResponseEntity.ok(ApiResponse.success(null, "해시태그 팔로우 완료"));
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success(null, "해시태그 팔로우 완료"));
     }
 
     // 해시태그 언팔로우 — DELETE /api/hashtags/{hashtagId}/follow

--- a/src/main/java/com/instagram/backend/domain/hashtag/dto/response/HashtagResponse.java
+++ b/src/main/java/com/instagram/backend/domain/hashtag/dto/response/HashtagResponse.java
@@ -1,0 +1,25 @@
+package com.instagram.backend.domain.hashtag.dto.response;
+
+import com.instagram.backend.domain.hashtag.entity.Hashtag;
+import lombok.Getter;
+
+@Getter
+public class HashtagResponse {
+    private final Long hashtagId;
+    private final String name;
+    private final int postCount;
+
+    private HashtagResponse(Long hashtagId, String name, int postCount) {
+        this.hashtagId = hashtagId;
+        this.name = name;
+        this.postCount = postCount;
+    }
+
+    public static HashtagResponse from(Hashtag hashtag) {
+        return new HashtagResponse(
+                hashtag.getHashtagId(),
+                hashtag.getName(),
+                hashtag.getPostCount()
+        );
+    }
+}

--- a/src/main/java/com/instagram/backend/domain/hashtag/entity/Hashtag.java
+++ b/src/main/java/com/instagram/backend/domain/hashtag/entity/Hashtag.java
@@ -1,0 +1,39 @@
+package com.instagram.backend.domain.hashtag.entity;
+
+import com.instagram.backend.global.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "hashtags")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Hashtag extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long hashtagId;
+
+    @Column(nullable = false, unique = true, length = 100)
+    private String name;
+
+    @Column(nullable = false)
+    private int postCount = 0;
+
+    @Builder
+    public Hashtag(String name) {
+        this.name = name;
+        this.postCount = 0;
+    }
+
+    public void increasePostCount() {
+        this.postCount++;
+    }
+
+    public void decreasePostCount() {
+        if (this.postCount > 0) this.postCount--;
+    }
+}

--- a/src/main/java/com/instagram/backend/domain/hashtag/entity/HashtagFollow.java
+++ b/src/main/java/com/instagram/backend/domain/hashtag/entity/HashtagFollow.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "hashtag_follows")
+@Table(name = "hashtag_follows", uniqueConstraints = @UniqueConstraint(name = "uk_hashtag_follows_member_hashtag", columnNames = {"member_id", "hashtag_id"}))
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class HashtagFollow {
@@ -15,10 +15,10 @@ public class HashtagFollow {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long hashtagFollowId;
 
-    @Column(nullable = false)
+    @Column(nullable = false, name = "member_id")
     private Long memberId;
 
-    @Column(nullable = false)
+    @Column(nullable = false, name = "hashtag_id")
     private Long hashtagId;
 
     @Builder

--- a/src/main/java/com/instagram/backend/domain/hashtag/entity/HashtagFollow.java
+++ b/src/main/java/com/instagram/backend/domain/hashtag/entity/HashtagFollow.java
@@ -1,0 +1,29 @@
+package com.instagram.backend.domain.hashtag.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "hashtag_follows")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class HashtagFollow {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long hashtagFollowId;
+
+    @Column(nullable = false)
+    private Long memberId;
+
+    @Column(nullable = false)
+    private Long hashtagId;
+
+    @Builder
+    public HashtagFollow(Long memberId, Long hashtagId) {
+        this.memberId = memberId;
+        this.hashtagId = hashtagId;
+    }
+}

--- a/src/main/java/com/instagram/backend/domain/hashtag/entity/PostHashtag.java
+++ b/src/main/java/com/instagram/backend/domain/hashtag/entity/PostHashtag.java
@@ -1,0 +1,30 @@
+package com.instagram.backend.domain.hashtag.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "post_hashtags")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PostHashtag {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long postHashtagId;
+
+    @Column(nullable = false)
+    private Long postId;
+
+    @Column(nullable = false)
+    private Long hashtagId;
+
+    @Builder
+    public PostHashtag(Long postId, Long hashtagId) {
+        this.postId = postId;
+        this.hashtagId = hashtagId;
+    }
+}

--- a/src/main/java/com/instagram/backend/domain/hashtag/repository/HashtagFollowRepository.java
+++ b/src/main/java/com/instagram/backend/domain/hashtag/repository/HashtagFollowRepository.java
@@ -1,7 +1,7 @@
 package com.instagram.backend.domain.hashtag.repository;
 
 import com.instagram.backend.domain.hashtag.entity.HashtagFollow;
-import io.lettuce.core.dynamic.annotation.Param;
+import org.springframework.data.repository.query.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 

--- a/src/main/java/com/instagram/backend/domain/hashtag/repository/HashtagFollowRepository.java
+++ b/src/main/java/com/instagram/backend/domain/hashtag/repository/HashtagFollowRepository.java
@@ -1,0 +1,19 @@
+package com.instagram.backend.domain.hashtag.repository;
+
+import com.instagram.backend.domain.hashtag.entity.HashtagFollow;
+import io.lettuce.core.dynamic.annotation.Param;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface HashtagFollowRepository extends JpaRepository<HashtagFollow, Long> {
+    // 중복방지
+    boolean existsByMemberIdAndHashtagId(Long memberId , Long hashtagId);
+    //언팔 시 사용
+    Optional<HashtagFollow> findByMemberIdAndHashtagId(Long memberId, Long hashtagId);
+    // 내가 팔로우하는 해시태그 ID 목록 (피드 확장용)
+    @Query("SELECT hf.hashtagId FROM HashtagFollow hf WHERE hf.memberId = :memberId")
+    List<Long> findHashtagIdsByMemberId(@Param("memberId") Long memberId);
+}

--- a/src/main/java/com/instagram/backend/domain/hashtag/repository/HashtagRepository.java
+++ b/src/main/java/com/instagram/backend/domain/hashtag/repository/HashtagRepository.java
@@ -9,7 +9,9 @@ import java.util.Optional;
 public interface HashtagRepository extends JpaRepository<Hashtag, Long> {
 
     Optional<Hashtag> findByName(String name);
-    // in절로 일괄조회
+    // 이름 목록으로 일괄 조회 (N+1 방지)
+    List<Hashtag> findByNameIn(List<String> names);
+    // ID 목록으로 일괄 조회
     List<Hashtag> findByHashtagIdIn(List<Long> hashtagIds);
 
 }

--- a/src/main/java/com/instagram/backend/domain/hashtag/repository/HashtagRepository.java
+++ b/src/main/java/com/instagram/backend/domain/hashtag/repository/HashtagRepository.java
@@ -1,0 +1,15 @@
+package com.instagram.backend.domain.hashtag.repository;
+
+import com.instagram.backend.domain.hashtag.entity.Hashtag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface HashtagRepository extends JpaRepository<Hashtag, Long> {
+
+    Optional<Hashtag> findByName(String name);
+    // in절로 일괄조회
+    List<Hashtag> findByHashtagIdIn(List<Long> hashtagIds);
+
+}

--- a/src/main/java/com/instagram/backend/domain/hashtag/repository/PostHashtagRepository.java
+++ b/src/main/java/com/instagram/backend/domain/hashtag/repository/PostHashtagRepository.java
@@ -1,0 +1,24 @@
+package com.instagram.backend.domain.hashtag.repository;
+
+import com.instagram.backend.domain.hashtag.entity.PostHashtag;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface PostHashtagRepository extends JpaRepository<PostHashtag, Long> {
+    //게시물 삭제할 때 카운트 관련
+    @Query("""
+    SELECT ph.hashtagId FROM PostHashtag ph WHERE ph.postId = :postId
+""")
+    List<Long> findHashtagIdsByPostId(@Param("postId") Long postId);
+    // 게시물의 여러 해시태그 일괄조회
+    @Query("""
+    SELECT DISTINCT ph.postId FROM PostHashtag ph WHERE ph.hashtagId IN :hashtagIds
+""")
+    List<Long> findPostIdsByHashtagIdIn(@Param("hashtagIds") List<Long> hashtagIds);
+
+    //게시물 삭제할 때 모든 해시태그 삭제할 때
+    List<PostHashtag> findByPostId(Long postId);
+}

--- a/src/main/java/com/instagram/backend/domain/hashtag/service/HashtagFollowService.java
+++ b/src/main/java/com/instagram/backend/domain/hashtag/service/HashtagFollowService.java
@@ -5,9 +5,10 @@ import com.instagram.backend.domain.hashtag.repository.HashtagFollowRepository;
 import com.instagram.backend.domain.hashtag.repository.HashtagRepository;
 import com.instagram.backend.global.exception.BusinessException;
 import com.instagram.backend.global.exception.ErrorCode;
-import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -18,24 +19,44 @@ public class HashtagFollowService {
     private final HashtagRepository hashtagRepository;
 
 
+    private void validateIds(Long memberId, Long hashtagId) {
+        if (memberId == null || hashtagId == null) {
+            throw new BusinessException(ErrorCode.MISSING_REQUIRED_FIELD);
+        }
+    }
+
     // 해시태그 팔로우
     @Transactional
-    public void followHashtag(Long memberId, Long hashtagId){
-        //해시태그 확인
+    public void followHashtag(Long memberId, Long hashtagId) {
+        // 값 자체 유효성 검증
+        validateIds(memberId, hashtagId);
+
+        // DB 존재 여부 확인
         hashtagRepository.findById(hashtagId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.HASHTAG_NOT_FOUND));
-        //팔로우 중인 지 확인
+
+        // 비즈니스 규칙 — 빠른 경로 체크 후 DB 유니크 제약으로 동시성 보장
         if (hashtagFollowRepository.existsByMemberIdAndHashtagId(memberId, hashtagId)) {
             throw new BusinessException(ErrorCode.ALREADY_HASHTAG_FOLLOWED);
         }
-        hashtagFollowRepository.save(HashtagFollow.builder()
-                .memberId(memberId)
-                .hashtagId(hashtagId)
-                .build());
+        try {
+            hashtagFollowRepository.save(HashtagFollow.builder()
+                    .memberId(memberId)
+                    .hashtagId(hashtagId)
+                    .build());
+        } catch (DataIntegrityViolationException e) {
+            // 동시 요청으로 유니크 제약 위반 → 동일 비즈니스 예외로 변환
+            throw new BusinessException(ErrorCode.ALREADY_HASHTAG_FOLLOWED);
+        }
     }
+
     // 해시태그 언팔로우
     @Transactional
     public void unfollowHashtag(Long memberId, Long hashtagId) {
+        // 값 자체 유효성 검증
+        validateIds(memberId, hashtagId);
+
+        // DB 존재 여부 확인
         HashtagFollow follow = hashtagFollowRepository
                 .findByMemberIdAndHashtagId(memberId, hashtagId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.HASHTAG_FOLLOW_NOT_FOUND));

--- a/src/main/java/com/instagram/backend/domain/hashtag/service/HashtagFollowService.java
+++ b/src/main/java/com/instagram/backend/domain/hashtag/service/HashtagFollowService.java
@@ -1,0 +1,45 @@
+package com.instagram.backend.domain.hashtag.service;
+
+import com.instagram.backend.domain.hashtag.entity.HashtagFollow;
+import com.instagram.backend.domain.hashtag.repository.HashtagFollowRepository;
+import com.instagram.backend.domain.hashtag.repository.HashtagRepository;
+import com.instagram.backend.global.exception.BusinessException;
+import com.instagram.backend.global.exception.ErrorCode;
+import org.springframework.transaction.annotation.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class HashtagFollowService {
+
+    private final HashtagFollowRepository hashtagFollowRepository;
+    private final HashtagRepository hashtagRepository;
+
+
+    // 해시태그 팔로우
+    @Transactional
+    public void followHashtag(Long memberId, Long hashtagId){
+        //해시태그 확인
+        hashtagRepository.findById(hashtagId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.HASHTAG_NOT_FOUND));
+        //팔로우 중인 지 확인
+        if (hashtagFollowRepository.existsByMemberIdAndHashtagId(memberId, hashtagId)) {
+            throw new BusinessException(ErrorCode.ALREADY_HASHTAG_FOLLOWED);
+        }
+        hashtagFollowRepository.save(HashtagFollow.builder()
+                .memberId(memberId)
+                .hashtagId(hashtagId)
+                .build());
+    }
+    // 해시태그 언팔로우
+    @Transactional
+    public void unfollowHashtag(Long memberId, Long hashtagId) {
+        HashtagFollow follow = hashtagFollowRepository
+                .findByMemberIdAndHashtagId(memberId, hashtagId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.HASHTAG_FOLLOW_NOT_FOUND));
+
+        hashtagFollowRepository.delete(follow);
+    }
+}

--- a/src/main/java/com/instagram/backend/domain/hashtag/service/HashtagService.java
+++ b/src/main/java/com/instagram/backend/domain/hashtag/service/HashtagService.java
@@ -1,0 +1,28 @@
+package com.instagram.backend.domain.hashtag.service;
+
+import com.instagram.backend.domain.hashtag.dto.response.HashtagResponse;
+import com.instagram.backend.domain.hashtag.entity.Hashtag;
+import com.instagram.backend.domain.hashtag.repository.HashtagRepository;
+import com.instagram.backend.global.exception.BusinessException;
+import com.instagram.backend.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class HashtagService {
+
+    private final HashtagRepository hashtagRepository;
+    //해시 태그 단건 조회
+    public HashtagResponse getHashtag(String name) {
+        if (name == null || name.isBlank()){
+            throw new BusinessException(ErrorCode.MISSING_REQUIRED_FIELD);
+        }
+        Hashtag hashtag = hashtagRepository.findByName(name.toLowerCase())
+                .orElseThrow(() -> new BusinessException(ErrorCode.HASHTAG_NOT_FOUND));
+        return HashtagResponse.from(hashtag);
+    }
+
+}

--- a/src/main/java/com/instagram/backend/domain/post/dto/PostCreateRequest.java
+++ b/src/main/java/com/instagram/backend/domain/post/dto/PostCreateRequest.java
@@ -17,5 +17,5 @@ public class PostCreateRequest {
 
     private List<PostImageRequest> images;
 
-
+    private List<String> hashtags;
 }

--- a/src/main/java/com/instagram/backend/domain/post/service/PostService.java
+++ b/src/main/java/com/instagram/backend/domain/post/service/PostService.java
@@ -2,6 +2,10 @@ package com.instagram.backend.domain.post.service;
 
 import com.instagram.backend.domain.bookmark.repository.BookmarkRepository;
 import com.instagram.backend.domain.comment.repository.CommentRepository;
+import com.instagram.backend.domain.hashtag.entity.Hashtag;
+import com.instagram.backend.domain.hashtag.entity.PostHashtag;
+import com.instagram.backend.domain.hashtag.repository.HashtagRepository;
+import com.instagram.backend.domain.hashtag.repository.PostHashtagRepository;
 import com.instagram.backend.domain.member.entity.Member;
 import com.instagram.backend.domain.member.repository.MemberRepository;
 import com.instagram.backend.domain.post.dto.PostCreateRequest;
@@ -19,7 +23,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @Service
 @RequiredArgsConstructor
@@ -32,6 +40,8 @@ public class PostService {
     private final BookmarkRepository bookmarkRepository;
     private final CommentRepository commentRepository;
     private final MemberRepository memberRepository;
+    private final HashtagRepository hashtagRepository;
+    private final PostHashtagRepository postHashtagRepository;
 
     // 게시물 단건 조회
     public PostResponse getPost(Long memberId, Long postId) {
@@ -87,6 +97,8 @@ public class PostService {
                     .build();
             postImageRepository.save(postImage);
         }
+        //해시태그 추출과 저장
+        saveHashtags(post.getPostId(), request.getPostContents(), request.getHashtags());
 
         return PostCreateResponse.from(post);
     }
@@ -121,6 +133,46 @@ public class PostService {
             throw new BusinessException(ErrorCode.FORBIDDEN);
         }
 
+        // 연결된 해시태그 카운트 감소
+        List<Long> linkedHashtagIds = postHashtagRepository.findHashtagIdsByPostId(postId);//한 게시물의 해시태그 조회
+        if (!linkedHashtagIds.isEmpty()) {//해시태그 있을 때 한방에 조회
+            List<Hashtag> hashtags = hashtagRepository.findByHashtagIdIn(linkedHashtagIds);
+            hashtags.forEach(Hashtag::decreasePostCount); // 해시태그 각각의 숫자 감소
+            // PostHashtag 레코드는 물리 삭제 (중간 테이블 완전 삭제)
+            postHashtagRepository.deleteAll(postHashtagRepository.findByPostId(postId));
+        }
+
         post.softDelete();
+    }
+
+    private void saveHashtags(Long postId, String contents, List<String> requestTags) {
+        //본문에서 태그 추출
+        Set<String> tagNames = new HashSet<>();
+        if (contents != null) {
+            Matcher matcher = Pattern.compile("#([\\w가-힣]+)").matcher(contents);//정규표현식을 자바가 읽을 수 있게 컴파일 된 것을 검색
+            while (matcher.find()) { //find : 해시태그 있는 지 탐색
+                tagNames.add(matcher.group(1).toLowerCase());//group(1): 정규표현식읠 그룹캐처 기능 : 정규표현식의 첫번 째괄호랑 매칭되는 문자열 가져오기
+            }
+        }
+
+        if (requestTags != null) {
+            requestTags.stream()
+                    .map(String::toLowerCase)//소문자로 변환
+                    .forEach(tagNames::add);//빈 해시태그 값에 추가
+        }
+
+        for (String tagName : tagNames) {
+            Hashtag hashtag = hashtagRepository.findByName(tagName)
+                    .orElseGet(() -> hashtagRepository.save(
+                            Hashtag.builder().name(tagName).build()
+                    ));
+            //카운트 증가
+            hashtag.increasePostCount();
+
+            postHashtagRepository.save(PostHashtag.builder()
+                    .postId(postId)
+                    .hashtagId(hashtag.getHashtagId())
+                    .build());
+        }
     }
 }

--- a/src/main/java/com/instagram/backend/domain/post/service/PostService.java
+++ b/src/main/java/com/instagram/backend/domain/post/service/PostService.java
@@ -23,11 +23,16 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import org.springframework.dao.DataIntegrityViolationException;
+
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -133,13 +138,14 @@ public class PostService {
             throw new BusinessException(ErrorCode.FORBIDDEN);
         }
 
-        // 연결된 해시태그 카운트 감소
-        List<Long> linkedHashtagIds = postHashtagRepository.findHashtagIdsByPostId(postId);//한 게시물의 해시태그 조회
-        if (!linkedHashtagIds.isEmpty()) {//해시태그 있을 때 한방에 조회
+        // 연결된 해시태그 카운트 감소 — findByPostId 한 번만 조회해서 재사용
+        List<PostHashtag> postHashtags = postHashtagRepository.findByPostId(postId);
+        if (!postHashtags.isEmpty()) {
+            List<Long> linkedHashtagIds = postHashtags.stream()
+                    .map(PostHashtag::getHashtagId).toList();
             List<Hashtag> hashtags = hashtagRepository.findByHashtagIdIn(linkedHashtagIds);
-            hashtags.forEach(Hashtag::decreasePostCount); // 해시태그 각각의 숫자 감소
-            // PostHashtag 레코드는 물리 삭제 (중간 테이블 완전 삭제)
-            postHashtagRepository.deleteAll(postHashtagRepository.findByPostId(postId));
+            hashtags.forEach(Hashtag::decreasePostCount);
+            postHashtagRepository.deleteAll(postHashtags);
         }
 
         post.softDelete();
@@ -155,20 +161,42 @@ public class PostService {
             }
         }
 
+        // null·blank 원소 필터링
         if (requestTags != null) {
             requestTags.stream()
-                    .map(String::toLowerCase)//소문자로 변환
-                    .forEach(tagNames::add);//빈 해시태그 값에 추가
+                    .filter(tag -> tag != null && !tag.isBlank())
+                    .map(tag -> tag.trim().toLowerCase())
+                    .forEach(tagNames::add);
+        }
+
+        if (tagNames.isEmpty()) return;
+
+        // N+1 → 배치 조회 후 없는 것만 saveAll
+        List<Hashtag> existing = hashtagRepository.findByNameIn(new ArrayList<>(tagNames));
+        Map<String, Hashtag> hashtagMap = existing.stream()
+                .collect(Collectors.toMap(Hashtag::getName, h -> h));
+
+        List<Hashtag> newHashtags = tagNames.stream()
+                .filter(name -> !hashtagMap.containsKey(name))
+                .map(name -> Hashtag.builder().name(name).build())
+                .collect(Collectors.toList());
+
+        if (!newHashtags.isEmpty()) {
+            try {
+                hashtagRepository.saveAll(newHashtags)
+                        .forEach(h -> hashtagMap.put(h.getName(), h));
+            } catch (DataIntegrityViolationException e) {
+                // 동시 삽입 충돌 시 이미 저장된 행 재조회
+                hashtagRepository.findByNameIn(
+                        newHashtags.stream().map(Hashtag::getName).toList()
+                ).forEach(h -> hashtagMap.put(h.getName(), h));
+            }
         }
 
         for (String tagName : tagNames) {
-            Hashtag hashtag = hashtagRepository.findByName(tagName)
-                    .orElseGet(() -> hashtagRepository.save(
-                            Hashtag.builder().name(tagName).build()
-                    ));
-            //카운트 증가
+            Hashtag hashtag = hashtagMap.get(tagName);
+            if (hashtag == null) continue;
             hashtag.increasePostCount();
-
             postHashtagRepository.save(PostHashtag.builder()
                     .postId(postId)
                     .hashtagId(hashtag.getHashtagId())

--- a/src/main/java/com/instagram/backend/domain/post/service/PostService.java
+++ b/src/main/java/com/instagram/backend/domain/post/service/PostService.java
@@ -27,7 +27,6 @@ import org.springframework.dao.DataIntegrityViolationException;
 
 import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;

--- a/src/main/java/com/instagram/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/instagram/backend/global/config/SecurityConfig.java
@@ -32,7 +32,8 @@ public class SecurityConfig {
             "/api/auth/refresh",
             "/api/auth/logout",
             "/actuator/health",
-            "/actuator/info"
+            "/actuator/info",
+            "/api/hashtags/**"
     };
 
     @Bean

--- a/src/main/java/com/instagram/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/instagram/backend/global/config/SecurityConfig.java
@@ -6,6 +6,7 @@ import com.instagram.backend.global.security.jwt.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -32,8 +33,7 @@ public class SecurityConfig {
             "/api/auth/refresh",
             "/api/auth/logout",
             "/actuator/health",
-            "/actuator/info",
-            "/api/hashtags/**"
+            "/actuator/info"
     };
 
     @Bean
@@ -54,6 +54,7 @@ public class SecurityConfig {
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(PUBLIC_URLS).permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/hashtags/*").permitAll()
                         .anyRequest().authenticated())
                 .exceptionHandling(ex -> ex
                         .authenticationEntryPoint(jwtAuthenticationEntryPoint)

--- a/src/main/java/com/instagram/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/instagram/backend/global/config/SecurityConfig.java
@@ -36,6 +36,10 @@ public class SecurityConfig {
             "/actuator/info"
     };
 
+    private static final String[] PUBLIC_GET_URLS = {
+            "/api/hashtags/*"
+    };
+
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
@@ -54,7 +58,7 @@ public class SecurityConfig {
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(PUBLIC_URLS).permitAll()
-                        .requestMatchers(HttpMethod.GET, "/api/hashtags/*").permitAll()
+                        .requestMatchers(HttpMethod.GET, PUBLIC_GET_URLS).permitAll()
                         .anyRequest().authenticated())
                 .exceptionHandling(ex -> ex
                         .authenticationEntryPoint(jwtAuthenticationEntryPoint)

--- a/src/main/java/com/instagram/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/instagram/backend/global/exception/ErrorCode.java
@@ -63,6 +63,7 @@ public enum ErrorCode {
     ALREADY_FOLLOWING(409, "이미 팔로우한 사용자입니다."),
     ALREADY_COMMENT_LIKED(409, "이미 좋아요한 댓글입니다."),
     ROOM_ALREADY_EXISTS(409, "이미 존재하는 채팅방입니다."),
+    ALREADY_HASHTAG_FOLLOWED(409, "이미 팔로우한 해시태그입니다."),
 
     // 500 - 서버 오류
     INTERNAL_SERVER_ERROR(500, "서버 오류가 발생했습니다.");

--- a/src/main/java/com/instagram/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/instagram/backend/global/exception/ErrorCode.java
@@ -52,6 +52,8 @@ public enum ErrorCode {
     COMMENT_NOT_FOUND(404, "존재하지 않는 댓글입니다."),
     COMMENT_LIKE_NOT_FOUND(404, "댓글 좋아요 내역이 존재하지 않습니다."),
     ROOM_NOT_FOUND(404, "존재하지 않는 채팅방입니다."),
+    HASHTAG_NOT_FOUND(404, "존재하지 않는 해시태그입니다."),
+    HASHTAG_FOLLOW_NOT_FOUND(404, "해시태그 팔로우 내역이 존재하지 않습니다."),
 
     // 409 - 중복
     DUPLICATE_EMAIL(409, "이미 사용 중인 이메일입니다."),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 해시태그 조회(비인증 GET) 추가 — 이름으로 해시태그 정보 확인 가능
  * 해시태그 팔로우/언팔로우 추가 — 팔로우 생성·취소 및 중복 방지 (POST/DELETE)
  * 게시물 작성/삭제 시 해시태그 자동 처리 — 콘텐츠와 요청값에서 추출해 저장·연결하고 게시물 수 반영
  * 게시물 생성 요청에 hashtags 필드 추가
* **버그 수정 / 오류 개선**
  * 해시태그 관련 오류 코드 및 메시지 추가/명확화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



## 배울 수 있는 내용
1. 입력 검순 순서 원칙
- 값 자체가 유효한지 (validateIds(memberId, hashtagId); 를 만들어서)
- DB 존재 여부 확인 후(hashtagRepository.findById(hashtagId)...) 비즈니스 규칙 작성 
2. TOCTOU(Time-Of-Check-Time-Of-Use) 경쟁 조건

- 위험: 두 요청이 동시에 exists=false를 보고 둘 다 save 시도
  if (exists(...)) throw ALREADY;
  save(...);

- 안전: DB 유니크 제약 + 예외 변환
  try {
      save(...);
  } catch (DataIntegrityViolationException e) {
      throw new BusinessException(ALREADY_HASHTAG_FOLLOWED);
  }

- exists랑 save 사이에 다른 스레드가 끼어들 수도 있고 동시성을 app 레벨 체크만으로 보장이 안됨

3. N+1 문제 — 두 가지 패턴
 패턴 A: 루프 안 단건 조회 → 배치 조회

  N번 쿼리
  for (String tagName : tagNames) {
      hashtagRepository.findByName(tagName); // N번 for문이니까
  }

  1번 쿼리
  List<Hashtag> existing = hashtagRepository.findByNameIn(tagNames); // 1번
  Map<String, Hashtag> map = existing.stream()
      .collect(Collectors.toMap(Hashtag::getName, h -> h));

  패턴 B: 같은 데이터 두 번 조회 → 재사용
  2번 조회
  postHashtagRepository.findHashtagIdsByPostId(postId); // 1번
  postHashtagRepository.findByPostId(postId);  // 2번 (같은 데이터)

  1번 조회 후 재사용
  List<PostHashtag> postHashtags = postHashtagRepository.findByPostId(postId); //1번
  List<Long> ids = postHashtags.stream().map(PostHashtag::getHashtagId).toList();
  postHashtagRepository.deleteAll(postHashtags); // 같은 리스트 재사용

4. 원자적 UPDATE로 동시성 안전한 카운트 관리

- SELECT → 자바에서 +1 → UPDATE (동시 요청 시 유실)
  comment.increaseLikeCount();

- DB가 직접 계산 (원자적)
  @Modifying
  @Query("UPDATE Comment c SET c.likeCount = c.likeCount + 1 WHERE ...")
  int incrementLikeCountAndIsDeletedFalse(Long commentId);

5. 스트림에서 null/blank 방어

  - null 원소나 빈 문자열이 섞이면 NPE 또는 잘못된 데이터 저장
  requestTags.stream()
      .map(String::toLowerCase)
      .forEach(tagNames::add);

  -  먼저 거르고 정제 후 처리
  requestTags.stream()
      .filter(tag -> tag != null && !tag.isBlank()) //먼저 거르기
      .map(tag -> tag.trim().toLowerCase())
      .forEach(tagNames::add);


6. 너무 넓음: follow/unfollow까지 열림
  "/api/hashtags/**"  // PUBLIC_URLS에 있으면 모든 메서드 허용

  메서드 단위로 정밀하게
  .requestMatchers(PUBLIC_URLS).permitAll() // 메서드 무관 공개
  .requestMatchers(HttpMethod.GET, PUBLIC_GET_URLS).permitAll()  // GET만 공개
  .anyRequest().authenticated() // 나머지는 인증 필수

  토큰 없이 POST /api/hashtags/{id}/follow를 호출하면 @AuthenticationPrincipal이 null을 주입 →
  userDetails.getMemberId()에서 NPE가 납니다. Security 설정이 잘못되면 컨트롤러 레벨 방어 코드가 아무 의미가
  없어집니다.

7. 공개 URL 상수 중앙화

  // 유지보수 관점: 새 공개 URL 추가할 때 한 곳만 보면 됨
  private static final String[] PUBLIC_URLS = { ... };      // 메서드 무관
  private static final String[] PUBLIC_GET_URLS = { ... };  // GET만 허용

