### PR TITLE
  feat: 메시지 읽음 처리 API 구현 (PATCH /api/chats/{roomId}/messages/{messageId}/read)

### DIFF
--- a/src/main/java/com/instagram/backend/domain/chat/entity/ChatRoomMember.java
+++ b/src/main/java/com/instagram/backend/domain/chat/entity/ChatRoomMember.java
@@ -35,4 +35,22 @@ public class ChatRoomMember {
         this.memberId = memberId;
         this.joinAt = joinAt;
     }
+
+    /*
+      읽음 처리 — lastReadMessageId 갱신
+
+      목적: 사용자가 특정 메시지까지 읽었음을 기록
+        — 이 값은 GET /api/chats의 unread_count 계산에 사용됨
+        — MessageRepository.countByChatRoomIdAndMessageIdGreaterThan(roomId, lastReadMessageId)
+
+      방어 로직: 현재 값보다 작은(= 더 오래된) messageId로 갱신 시도하면 무시
+        — 예: 최신 메시지 50까지 읽었는데 PATCH로 30을 보내면 50 유지
+        — 프론트가 실수로 과거 메시지를 보내도 unread_count가 늘어나지 않도록 보호
+    */
+    public void updateLastReadMessageId(Long messageId) {
+        if (messageId == null) return;
+        if (this.lastReadMessageId == null || messageId > this.lastReadMessageId) {
+            this.lastReadMessageId = messageId;
+        }
+    }
 }

--- a/src/main/java/com/instagram/backend/domain/chat/repository/ChatRoomMemberRepository.java
+++ b/src/main/java/com/instagram/backend/domain/chat/repository/ChatRoomMemberRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 
 public interface ChatRoomMemberRepository extends JpaRepository<ChatRoomMember, Long> {
 
@@ -73,4 +74,13 @@ public interface ChatRoomMemberRepository extends JpaRepository<ChatRoomMember, 
           ) = 2
         """)
     List<Long> findDmRoomIdBetween(@Param("myId") Long myId, @Param("otherId") Long otherId);
+
+    /*
+      특정 채팅방에서 특정 유저의 ChatRoomMember 엔티티 조회
+
+      목적: 읽음 처리 API에서 lastReadMessageId 갱신을 위해 엔티티가 필요
+        — existsBy...는 존재 여부만 반환하므로 엔티티를 수정할 수 없음
+        — 이 메서드로 엔티티를 가져와서 updateLastReadMessageId()를 호출한 뒤 dirty checking으로 저장
+    */
+    Optional<ChatRoomMember> findByChatRoomIdAndMemberId(Long chatRoomId, Long memberId);
 }

--- a/src/main/java/com/instagram/backend/domain/message/controller/MessageController.java
+++ b/src/main/java/com/instagram/backend/domain/message/controller/MessageController.java
@@ -14,6 +14,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -98,6 +99,35 @@ public class MessageController {
 
         return ResponseEntity.ok(
                 ApiResponse.success(response, "메시지 목록 조회에 성공하였습니다.")
+        );
+    }
+
+    /*
+      PATCH /api/chats/{roomId}/messages/{messageId}/read — 메시지 읽음 처리
+
+      동작:
+        — chat_room_members.last_read_message_id를 해당 messageId로 갱신
+        — 이 값은 GET /api/chats 의 unread_count 계산에 사용됨
+        — 이미 더 최신 메시지를 읽은 상태면 값이 되돌아가지 않음 (방어 로직 내장)
+
+      응답:
+        — 200 OK + 성공 메시지만 반환 (data 없음)
+        — 읽음 처리는 부수효과(side effect)이므로 별도 응답 데이터가 필요 없음
+    */
+    @PatchMapping("/{messageId}/read")
+    public ResponseEntity<ApiResponse<Void>> markAsRead(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long roomId,
+            @PathVariable Long messageId) {
+
+        if (userDetails == null) {
+            throw new BusinessException(ErrorCode.UNAUTHORIZED);
+        }
+
+        messageService.markAsRead(userDetails.getMemberId(), roomId, messageId);
+
+        return ResponseEntity.ok(
+                ApiResponse.success(null, "메시지를 읽음 처리하였습니다.")
         );
     }
 }

--- a/src/main/java/com/instagram/backend/domain/message/repository/MessageRepository.java
+++ b/src/main/java/com/instagram/backend/domain/message/repository/MessageRepository.java
@@ -59,4 +59,13 @@ public interface MessageRepository extends JpaRepository<Message, Long> {
     */
     List<Message> findByChatRoomIdAndIsDeletedFalseAndMessageIdLessThanOrderByMessageIdDesc(
             Long chatRoomId, Long cursor, Pageable pageable);
+
+    /*
+      단건 메시지 조회 (소프트 삭제 제외)
+
+      목적: 읽음 처리 API에서 해당 메시지가 실제로 존재하는지 검증
+        — findById(Long)은 소프트 삭제된 메시지도 반환하므로
+          프로젝트 전반의 "findByXxxIdAndIsDeletedFalse" 패턴을 따름
+    */
+    Optional<Message> findByMessageIdAndIsDeletedFalse(Long messageId);
 }

--- a/src/main/java/com/instagram/backend/domain/message/service/MessageService.java
+++ b/src/main/java/com/instagram/backend/domain/message/service/MessageService.java
@@ -1,5 +1,6 @@
 package com.instagram.backend.domain.message.service;
 
+import com.instagram.backend.domain.chat.entity.ChatRoomMember;
 import com.instagram.backend.domain.chat.repository.ChatRoomMemberRepository;
 import com.instagram.backend.domain.chat.repository.ChatRoomRepository;
 import com.instagram.backend.domain.member.entity.Member;
@@ -297,6 +298,50 @@ public class MessageService {
                 : null;
 
         return CursorPageResponse.of(content, nextCursor, hasNext);
+    }
+
+    /*
+      메시지 읽음 처리 — PATCH /api/chats/{roomId}/messages/{messageId}/read
+
+      처리 순서:
+        1) 방 존재 + 참여자 검증 (validateRoomAndParticipant는 existsBy로만 확인하므로,
+           여기서는 findBy로 엔티티를 가져와야 lastReadMessageId 갱신이 가능)
+        2) 메시지 존재 + 해당 방 소속 검증
+        3) ChatRoomMember.lastReadMessageId 갱신 (dirty checking으로 자동 UPDATE)
+
+      왜 validateRoomAndParticipant()를 재사용하지 않나?
+        — validateRoomAndParticipant는 existsBy로 존재 여부만 확인
+        — 읽음 처리는 ChatRoomMember 엔티티의 필드를 수정해야 하므로 findBy로 가져와야 함
+        — 방 존재 검증은 그대로 재사용하고, 참여자 조회만 findBy로 교체
+
+      과거 메시지 방어:
+        — ChatRoomMember.updateLastReadMessageId() 내부에서
+          현재 값보다 작은 messageId는 무시하므로 별도 검증 불필요
+    */
+    @Transactional
+    public void markAsRead(Long myMemberId, Long roomId, Long messageId) {
+        // 1) 방 존재 검증 (소프트 삭제된 방 차단)
+        //    — 아래 findByChatRoomIdAndMemberId만으로도 참여자 부재를 잡을 수 있지만,
+        //      소프트 삭제된 방의 ChatRoomMember 레코드는 남아 있을 수 있으므로
+        //      방 자체의 is_deleted 상태를 먼저 확인해야 정확한 404를 보장함
+        chatRoomRepository.findByChatRoomIdAndIsDeletedFalse(roomId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ROOM_NOT_FOUND));
+
+        // 2) 참여자 검증 + 엔티티 획득 (lastReadMessageId 갱신용)
+        ChatRoomMember membership = chatRoomMemberRepository
+                .findByChatRoomIdAndMemberId(roomId, myMemberId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.CHAT_ROOM_FORBIDDEN));
+
+        // 3) 메시지 존재 + 해당 방 소속 검증
+        //    — 다른 방의 messageId를 보내면 chatRoomId 불일치로 MESSAGE_NOT_FOUND 처리
+        Message message = messageRepository.findByMessageIdAndIsDeletedFalse(messageId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MESSAGE_NOT_FOUND));
+        if (!message.getChatRoomId().equals(roomId)) {
+            throw new BusinessException(ErrorCode.MESSAGE_NOT_FOUND);
+        }
+
+        // 4) lastReadMessageId 갱신 — dirty checking으로 트랜잭션 커밋 시 자동 UPDATE
+        membership.updateLastReadMessageId(messageId);
     }
 
     // ===== private helpers =====

--- a/src/main/java/com/instagram/backend/domain/message/service/MessageService.java
+++ b/src/main/java/com/instagram/backend/domain/message/service/MessageService.java
@@ -139,7 +139,7 @@ public class MessageService {
                     throw new BusinessException(ErrorCode.MISSING_MESSAGE_CONTENT);
                 }
                 // 명세서 상 "story_visitor_id"라는 이름을 쓰지만 실제 DB 참조는 story_id
-                sharedStory = storyRepository.findByStoryIdAndIsDeletedFalseAndExpiresAtAfter(
+                sharedStory = storyRepository.findActiveStory(
                                 request.getStoryVisitorId(), LocalDateTime.now())
                         .orElseThrow(() -> new BusinessException(ErrorCode.STORY_NOT_FOUND));
             }

--- a/src/main/java/com/instagram/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/instagram/backend/global/exception/ErrorCode.java
@@ -52,6 +52,7 @@ public enum ErrorCode {
     COMMENT_NOT_FOUND(404, "존재하지 않는 댓글입니다."),
     COMMENT_LIKE_NOT_FOUND(404, "댓글 좋아요 내역이 존재하지 않습니다."),
     ROOM_NOT_FOUND(404, "존재하지 않는 채팅방입니다."),
+    MESSAGE_NOT_FOUND(404, "존재하지 않는 메시지입니다."),
 
     // 409 - 중복
     DUPLICATE_EMAIL(409, "이미 사용 중인 이메일입니다."),


### PR DESCRIPTION
  - PATCH /api/chats/{roomId}/messages/{messageId}/read — 읽음 처리 엔드포인트 추가
  - ChatRoomMember.updateLastReadMessageId() — 과거 메시지 방어 + null 가드 포함
  - ChatRoomMemberRepository.findByChatRoomIdAndMemberId() — 엔티티 조회용 추가
  - MessageRepository.findByMessageIdAndIsDeletedFalse() — 소프트 삭제 일관성 확보
  - ErrorCode.MESSAGE_NOT_FOUND 추가
  - 검증: 방 존재(404) → 참여자(403) → 메시지 존재+방 소속(404) → lastReadMessageId 갱신
  - GET /api/chats의 unread_count와 연동 확인 (읽음 전 3 → 읽음 후 0)

  closes #47

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 채팅 메시지를 개별적으로 '읽음' 처리하는 API 추가 — 사용자가 메시지를 읽음 표시할 수 있고 시스템이 읽음 진행을 추적합니다.
* **버그 픽스 / 개선**
  * 읽음 위치 업데이트 시 이전(작은) 메시지 ID로 되돌아가지 않도록 보호하여 읽음 상태가 역전되는 문제 방지.
  * 존재하지 않는 메시지에 대해 적절한 404 오류를 반환하도록 검증 강화.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->