### PR TITLE
feat: 유저 검색 API 구현 (GET /api/search/users)

### DIFF
--- a/src/main/java/com/instagram/backend/domain/follow/repository/FollowRepository.java
+++ b/src/main/java/com/instagram/backend/domain/follow/repository/FollowRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.repository.query.Param;
 
 import org.springframework.data.domain.Pageable;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -67,4 +68,15 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
     // 내가 팔로우하는 사람들의 memberId 목록 조회 (스토리 피드용)
     @Query("SELECT f.followingId FROM Follow f WHERE f.followerId = :followerId")
     List<Long> findFollowingIdsByFollowerId(@Param("followerId") Long followerId);
+
+    /*
+      특정 대상 목록 중 내가 팔로우하고 있는 memberId만 반환 (배치 조회)
+
+      목적: 유저 검색 결과에 is_following 필드를 채울 때 N+1 회피
+        — existsByFollowerIdAndFollowingId()를 결과 수만큼 호출하는 대신
+          한 번의 IN 쿼리로 팔로우 중인 ID만 가져옴
+        — 반환된 Set에 포함 여부로 is_following 판단
+    */
+    @Query("SELECT f.followingId FROM Follow f WHERE f.followerId = :myId AND f.followingId IN :targetIds")
+    List<Long> findFollowingIdsAmong(@Param("myId") Long myId, @Param("targetIds") Collection<Long> targetIds);
 }

--- a/src/main/java/com/instagram/backend/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/instagram/backend/domain/member/repository/MemberRepository.java
@@ -1,7 +1,10 @@
 package com.instagram.backend.domain.member.repository;
 
 import com.instagram.backend.domain.member.entity.Member;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Collection;
 import java.util.List;
@@ -27,4 +30,25 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     // SELECT * FROM members WHERE member_id IN (?, ?, ...) AND is_deleted = false
     // 채팅방 참여자 목록, 메시지 발신자 정보 등 "여러 유저를 한 번에 가져와야 하는" 상황에 사용
     List<Member> findByMemberIdInAndIsDeletedFalse(Collection<Long> memberIds);
+
+    /*
+      유저 검색 — username 또는 name으로 LIKE 검색
+
+      목적: GET /api/search/users의 검색 결과 반환
+        — 소프트 삭제된 회원 제외
+        — 본인(myId) 제외 — 자기 자신은 검색 결과에 불필요
+        — username과 name 양쪽 모두 부분 일치 검색 (OR 조건)
+        — Pageable로 limit 제어
+
+      LIKE 검색:
+        — JPQL에서 LIKE CONCAT('%', :q, '%') 패턴 사용
+        — Spring Data JPA의 Containing 파생 메서드도 가능하지만,
+          OR 조건 + 본인 제외 + 삭제 제외를 한 쿼리에 담으려면 @Query가 깔끔함
+    */
+    @Query("SELECT m FROM Member m " +
+           "WHERE m.isDeleted = false " +
+           "AND m.memberId != :myId " +
+           "AND (m.memberUsername LIKE CONCAT('%', :q, '%') ESCAPE '\\' " +
+           "OR m.name LIKE CONCAT('%', :q, '%') ESCAPE '\\')")
+    List<Member> searchByUsernameOrName(@Param("myId") Long myId, @Param("q") String q, Pageable pageable);
 }

--- a/src/main/java/com/instagram/backend/domain/search/controller/SearchController.java
+++ b/src/main/java/com/instagram/backend/domain/search/controller/SearchController.java
@@ -1,0 +1,59 @@
+package com.instagram.backend.domain.search.controller;
+
+import com.instagram.backend.domain.search.dto.response.UserSearchResponse;
+import com.instagram.backend.domain.search.service.SearchService;
+import com.instagram.backend.global.dto.ApiResponse;
+import com.instagram.backend.global.security.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/*
+  SearchController — 검색 API
+
+  @RequestMapping("/api/search")
+    — 검색 관련 엔드포인트를 하나의 컨트롤러에 모음
+    — 향후 해시태그 검색(GET /api/search/hashtags) 추가 시에도 같은 컨트롤러에 배치
+
+  인증:
+    — 모든 엔드포인트는 JWT 인증 필요 (@AuthenticationPrincipal)
+    — is_following 판단에 로그인 유저의 memberId가 필요하기 때문
+*/
+@RestController
+@RequestMapping("/api/search")
+@RequiredArgsConstructor
+public class SearchController {
+
+    private final SearchService searchService;
+
+    /*
+      GET /api/search/users — 유저 검색
+
+      쿼리 파라미터:
+        — q (필수): 검색어. username 또는 name에 대해 LIKE 검색
+        — limit (선택): 결과 수. 기본 10, 최대 50
+
+      응답:
+        — members 배열 안에 각 유저의 기본 정보 + is_following
+        — 검색 결과가 없으면 빈 배열 반환 (404가 아닌 200 + 빈 리스트)
+    */
+    @GetMapping("/users")
+    public ResponseEntity<ApiResponse<UserSearchResponse>> searchUsers(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            // required=false로 받는 이유: 프레임워크 기본 예외(MissingServletRequestParameterException) 대신
+            // 명세서에 정의된 MISSING_REQUIRED_FIELD 에러코드를 서비스 레이어에서 직접 반환하기 위함
+            @RequestParam(required = false) String q,
+            @RequestParam(required = false) Integer limit) {
+
+        UserSearchResponse response = searchService.searchUsers(
+                userDetails.getMemberId(), q, limit);
+
+        return ResponseEntity.ok(
+                ApiResponse.success(response, "유저 검색에 성공하였습니다.")
+        );
+    }
+}

--- a/src/main/java/com/instagram/backend/domain/search/dto/response/UserSearchResponse.java
+++ b/src/main/java/com/instagram/backend/domain/search/dto/response/UserSearchResponse.java
@@ -1,0 +1,70 @@
+package com.instagram.backend.domain.search.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.instagram.backend.domain.member.entity.Member;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.Set;
+
+/*
+  UserSearchResponse — 유저 검색 응답 DTO
+
+  설계:
+    — 명세서(Search.pdf)의 응답 구조를 그대로 반영
+    — members 리스트 안에 각 유저의 기본 정보 + is_following 포함
+    — is_following: 내가 해당 유저를 팔로우하고 있는지 여부
+      → 검색 결과 화면에서 "팔로우" / "팔로잉" 버튼 상태를 결정할 때 사용
+
+  of() 팩토리 메서드:
+    — Member 엔티티 리스트 + 내가 팔로우 중인 ID Set을 받아 DTO 변환
+    — Set.contains()로 O(1) 팔로우 여부 판단 (N+1 회피)
+*/
+@Getter
+@Builder
+public class UserSearchResponse {
+
+    @JsonProperty("members")
+    private final List<UserInfo> members;
+
+    @Getter
+    @Builder
+    public static class UserInfo {
+
+        @JsonProperty("member_id")
+        private final Long memberId;
+
+        @JsonProperty("member_username")
+        private final String memberUsername;
+
+        @JsonProperty("member_name")
+        private final String memberName;
+
+        @JsonProperty("member_image_url")
+        private final String memberImageUrl;
+
+        @JsonProperty("member_image_uuid")
+        private final String memberImageUuid;
+
+        @JsonProperty("is_following")
+        private final boolean isFollowing;
+    }
+
+    public static UserSearchResponse of(List<Member> members, Set<Long> followingIds) {
+        List<UserInfo> userInfos = members.stream()
+                .map(m -> UserInfo.builder()
+                        .memberId(m.getMemberId())
+                        .memberUsername(m.getMemberUsername())
+                        .memberName(m.getName())
+                        .memberImageUrl(m.getImageUrl())
+                        .memberImageUuid(m.getImageUuid())
+                        .isFollowing(followingIds.contains(m.getMemberId()))
+                        .build())
+                .toList();
+
+        return UserSearchResponse.builder()
+                .members(userInfos)
+                .build();
+    }
+}

--- a/src/main/java/com/instagram/backend/domain/search/service/SearchService.java
+++ b/src/main/java/com/instagram/backend/domain/search/service/SearchService.java
@@ -1,0 +1,103 @@
+package com.instagram.backend.domain.search.service;
+
+import com.instagram.backend.domain.follow.repository.FollowRepository;
+import com.instagram.backend.domain.member.entity.Member;
+import com.instagram.backend.domain.member.repository.MemberRepository;
+import com.instagram.backend.domain.search.dto.response.UserSearchResponse;
+import com.instagram.backend.global.exception.BusinessException;
+import com.instagram.backend.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/*
+  SearchService — 검색 도메인 비즈니스 로직
+
+  담당 기능:
+    — searchUsers: GET /api/search/users
+
+  설계 원칙:
+    — 검색어(q)로 username과 name을 LIKE 검색 (OR 조건)
+    — 본인 제외, 소프트 삭제 제외
+    — is_following 판단은 IN 배치 조회로 N+1 회피
+      (검색 결과 memberId 목록 → FollowRepository.findFollowingIdsAmong() 한 번 호출)
+*/
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SearchService {
+
+    private static final int DEFAULT_LIMIT = 10;
+    private static final int MAX_LIMIT = 50;
+
+    private final MemberRepository memberRepository;
+    private final FollowRepository followRepository;
+
+    /*
+      유저 검색 — GET /api/search/users
+
+      처리 순서:
+        1) 검색어 검증 (null → MISSING_REQUIRED_FIELD, blank → INVALID_SEARCH_QUERY)
+        2) limit 정규화 (null이면 기본 10, 최대 50)
+        3) Member LIKE 검색 (username OR name, 본인 제외, isDeleted=false)
+        4) 검색 결과 memberId로 팔로우 여부 배치 조회
+        5) 응답 DTO 조립
+
+      검색 방식:
+        — LIKE '%q%' → DB 인덱스를 못 타므로 풀 스캔
+        — 대규모 서비스에서는 Elasticsearch 같은 검색 엔진이 필요하지만
+          학습 목적 프로젝트에서는 LIKE로 충분 (MVP)
+    */
+    public UserSearchResponse searchUsers(Long myMemberId, String q, Integer limit) {
+        // 1) 검색어 검증
+        if (q == null) {
+            throw new BusinessException(ErrorCode.MISSING_REQUIRED_FIELD);
+        }
+        String trimmed = q.trim();
+        if (trimmed.isEmpty()) {
+            throw new BusinessException(ErrorCode.INVALID_SEARCH_QUERY);
+        }
+
+        // LIKE 와일드카드 이스케이프
+        //   — 사용자가 '%' 또는 '_'를 검색어에 포함하면 LIKE 패턴으로 해석되어
+        //     의도치 않게 전체 회원이 반환될 수 있음 (정보 열거 위험)
+        //   — '%'와 '_'를 이스케이프하여 리터럴 문자로 취급하게 함
+        //   — JPQL 쿼리에 ESCAPE '\\' 절과 함께 동작
+        String escaped = trimmed
+                .replace("\\", "\\\\")
+                .replace("%", "\\%")
+                .replace("_", "\\_");
+
+        // 2) limit 검증
+        int size = (limit == null) ? DEFAULT_LIMIT : limit;
+        if (size < 1 || size > MAX_LIMIT) {
+            throw new BusinessException(ErrorCode.INVALID_LIMIT);
+        }
+
+        // 3) LIKE 검색 (본인 제외, 소프트 삭제 제외)
+        List<Member> members = memberRepository.searchByUsernameOrName(
+                myMemberId, escaped, PageRequest.of(0, size));
+
+        if (members.isEmpty()) {
+            // 빈 결과 early return — 아래 findFollowingIdsAmong()에 빈 컬렉션이 전달되는 것을 방지
+            // JPA의 IN () 절에 빈 컬렉션이 들어가면 구현체에 따라 SQL 에러 가능성 있음
+            return UserSearchResponse.of(Collections.emptyList(), Collections.emptySet());
+        }
+
+        // 4) 팔로우 여부 배치 조회 (N+1 회피)
+        //    — 검색 결과의 memberId를 모아서 한 번의 IN 쿼리로 처리
+        //    — 반환값은 내가 팔로우 중인 memberId 목록 → Set으로 변환하여 O(1) lookup
+        List<Long> memberIds = members.stream().map(Member::getMemberId).toList();
+        Set<Long> followingIds = new HashSet<>(
+                followRepository.findFollowingIdsAmong(myMemberId, memberIds));
+
+        // 5) 응답 조립
+        return UserSearchResponse.of(members, followingIds);
+    }
+}

--- a/src/main/java/com/instagram/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/instagram/backend/global/exception/ErrorCode.java
@@ -21,6 +21,7 @@ public enum ErrorCode {
     INVALID_GENDER_VALUE(400, "성별 값이 올바르지 않습니다. (MALE/FEMALE/OTHER)"),
     INVALID_IMAGE_TYPE(400, "지원하지 않는 이미지 형식입니다."),
     EXCEED_COMMENT_LENGTH(400, "댓글 내용은 500자 이내로 입력해주세요."),
+    INVALID_SEARCH_QUERY(400, "검색어는 1자 이상 입력해주세요."),
     INVALID_DTYPE(400, "올바르지 않은 메시지 타입입니다."),
     MISSING_MESSAGE_CONTENT(400, "메시지 내용을 입력해주세요."),
 


### PR DESCRIPTION
  - GET /api/search/users?q={검색어}&limit={결과수} — username/name LIKE 검색
  - SearchController, SearchService, UserSearchResponse 신규 생성
  - MemberRepository에 searchByUsernameOrName() LIKE 검색 메서드 추가 (본인 제외, 소프트 삭제 제외)
  - FollowRepository에 findFollowingIdsAmong() 배치 조회 추가 (is_following N+1 회피)
  - ErrorCode에 INVALID_SEARCH_QUERY 추가
  - LIKE 와일드카드(%/_) 이스케이프 처리로 전체 회원 열거 방지
  - 코드 리뷰 피드백 반영 (HIGH 1 + MEDIUM 2 + LOW 1)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 사용자 검색 기능 추가: 사용자명 또는 이름으로 검색 가능
  * 검색 결과에 프로필 정보 및 팔로우 상태 표시
  * 검색 결과 개수 제한 옵션 지원

<!-- end of auto-generated comment: release notes by coderabbit.ai -->