### PR TITLE
홈 피드(포스트 + 헤시테그) 제작

### DIFF
--- a/src/main/java/com/instagram/backend/domain/bookmark/repository/BookmarkRepository.java
+++ b/src/main/java/com/instagram/backend/domain/bookmark/repository/BookmarkRepository.java
@@ -3,9 +3,13 @@ package com.instagram.backend.domain.bookmark.repository;
 import com.instagram.backend.domain.bookmark.entity.Bookmark;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
     Optional<Bookmark> findByPostIdAndMemberId(Long postId, Long memberId);
@@ -23,4 +27,10 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
     // — LessThan 조건으로 "이미 본 데이터 이후" 만 가져오는 게 커서 방식의 핵심
     List<Bookmark> findByMemberIdAndBookmarkIdLessThanOrderByBookmarkIdDesc(
             Long memberId, Long cursor, Pageable pageable);
+
+    // 피드용 — 내가 저장한 postId Set (O(1) 조회로 N+1 방지)
+    @Query("SELECT b.postId FROM Bookmark b WHERE b.memberId = :memberId AND b.postId IN :postIds")
+    Set<Long> findPostIdsByMemberIdAndPostIdIn(
+            @Param("memberId") Long memberId,
+            @Param("postIds") Collection<Long> postIds);
 }

--- a/src/main/java/com/instagram/backend/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/instagram/backend/domain/comment/repository/CommentRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -36,4 +37,13 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     @Modifying
     @Query("UPDATE Comment c SET c.likeCount = c.likeCount - 1 WHERE c.commentId = :commentId AND c.isDeleted = false AND c.likeCount > 0")
     int decrementLikeCountAndIsDeletedFalse(@Param("commentId") Long commentId);
+
+    // 피드용 — 여러 게시물의 댓글 수 일괄 집계 [postId, count] 형태 반환
+    @Query("""
+        SELECT c.postId, COUNT(c)
+        FROM Comment c
+        WHERE c.postId IN :postIds AND c.isDeleted = false
+        GROUP BY c.postId
+    """)
+    List<Object[]> countByPostIdInAndIsDeletedFalse(@Param("postIds") Collection<Long> postIds);
 }

--- a/src/main/java/com/instagram/backend/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/instagram/backend/domain/comment/repository/CommentRepository.java
@@ -38,12 +38,12 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     @Query("UPDATE Comment c SET c.likeCount = c.likeCount - 1 WHERE c.commentId = :commentId AND c.isDeleted = false AND c.likeCount > 0")
     int decrementLikeCountAndIsDeletedFalse(@Param("commentId") Long commentId);
 
-    // 피드용 — 여러 게시물의 댓글 수 일괄 집계 [postId, count] 형태 반환
+    // 피드용 — 여러 게시물의 댓글 수 일괄 집계
     @Query("""
-        SELECT c.postId, COUNT(c)
+        SELECT c.postId AS postId, COUNT(c) AS count
         FROM Comment c
         WHERE c.postId IN :postIds AND c.isDeleted = false
         GROUP BY c.postId
     """)
-    List<Object[]> countByPostIdInAndIsDeletedFalse(@Param("postIds") Collection<Long> postIds);
+    List<PostCommentCount> countByPostIdInAndIsDeletedFalse(@Param("postIds") Collection<Long> postIds);
 }

--- a/src/main/java/com/instagram/backend/domain/comment/repository/PostCommentCount.java
+++ b/src/main/java/com/instagram/backend/domain/comment/repository/PostCommentCount.java
@@ -1,0 +1,6 @@
+package com.instagram.backend.domain.comment.repository;
+
+public interface PostCommentCount {
+    Long getPostId();
+    Long getCount();
+}

--- a/src/main/java/com/instagram/backend/domain/hashtag/repository/PostHashtagRepository.java
+++ b/src/main/java/com/instagram/backend/domain/hashtag/repository/PostHashtagRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.Collection;
 import java.util.List;
 
 public interface PostHashtagRepository extends JpaRepository<PostHashtag, Long> {
@@ -21,4 +22,8 @@ public interface PostHashtagRepository extends JpaRepository<PostHashtag, Long> 
 
     //게시물 삭제할 때 모든 해시태그 삭제할 때
     List<PostHashtag> findByPostId(Long postId);
+
+    // 피드용 — 여러 게시물의 PostHashtag 일괄 조회 (N+1 방지)
+    @Query("SELECT ph FROM PostHashtag ph WHERE ph.postId IN :postIds")
+    List<PostHashtag> findByPostIdIn(@Param("postIds") Collection<Long> postIds);
 }

--- a/src/main/java/com/instagram/backend/domain/post/controller/FeedController.java
+++ b/src/main/java/com/instagram/backend/domain/post/controller/FeedController.java
@@ -1,0 +1,32 @@
+package com.instagram.backend.domain.post.controller;
+
+import com.instagram.backend.domain.post.dto.response.FeedListResponse;
+import com.instagram.backend.domain.post.service.FeedService;
+import com.instagram.backend.global.dto.ApiResponse;
+import com.instagram.backend.global.security.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/feed")
+public class FeedController {
+
+    private final FeedService feedService;
+
+    // 홈 피드 조회 — GET /api/feed?cursor={cursor}&size={size}
+    @GetMapping
+    public ResponseEntity<ApiResponse<FeedListResponse>> getFeed(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(required = false) Long cursor,
+            @RequestParam(defaultValue = "20") int size) {
+        return ResponseEntity.ok(
+                ApiResponse.success(
+                        feedService.getFeed(userDetails.getMemberId(), cursor, size),
+                        "피드 조회 성공"
+                )
+        );
+    }
+}

--- a/src/main/java/com/instagram/backend/domain/post/dto/response/FeedListResponse.java
+++ b/src/main/java/com/instagram/backend/domain/post/dto/response/FeedListResponse.java
@@ -1,0 +1,33 @@
+package com.instagram.backend.domain.post.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class FeedListResponse {
+
+    @JsonProperty("posts")
+    private final List<FeedResponse> posts;
+
+    @JsonProperty("next_cursor")
+    private final Long nextCursor;
+
+    @JsonProperty("has_more")
+    private final boolean hasMore;
+
+    private FeedListResponse(List<FeedResponse> posts, Long nextCursor, boolean hasMore) {
+        this.posts = posts;
+        this.nextCursor = nextCursor;
+        this.hasMore = hasMore;
+    }
+
+    public static FeedListResponse of(List<FeedResponse> posts, Long nextCursor, boolean hasMore) {
+        return new FeedListResponse(posts, nextCursor, hasMore);
+    }
+
+    public static FeedListResponse empty() {
+        return new FeedListResponse(List.of(), null, false);
+    }
+}

--- a/src/main/java/com/instagram/backend/domain/post/dto/response/FeedListResponse.java
+++ b/src/main/java/com/instagram/backend/domain/post/dto/response/FeedListResponse.java
@@ -1,20 +1,16 @@
 package com.instagram.backend.domain.post.dto.response;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Getter;
 
 import java.util.List;
 
 @Getter
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class FeedListResponse {
 
-    @JsonProperty("posts")
     private final List<FeedResponse> posts;
-
-    @JsonProperty("next_cursor")
     private final Long nextCursor;
-
-    @JsonProperty("has_more")
     private final boolean hasMore;
 
     private FeedListResponse(List<FeedResponse> posts, Long nextCursor, boolean hasMore) {

--- a/src/main/java/com/instagram/backend/domain/post/dto/response/FeedResponse.java
+++ b/src/main/java/com/instagram/backend/domain/post/dto/response/FeedResponse.java
@@ -1,0 +1,91 @@
+package com.instagram.backend.domain.post.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.instagram.backend.domain.member.entity.Member;
+import com.instagram.backend.domain.post.entity.Post;
+import com.instagram.backend.domain.post.entity.PostImage;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+public class FeedResponse {
+
+    @JsonProperty("post_id")
+    private final Long postId;
+
+    @JsonProperty("content")
+    private final String content;
+
+    @JsonProperty("like_count")
+    private final int likeCount;
+
+    @JsonProperty("comment_count")
+    private final int commentCount;
+
+    @JsonProperty("comment_enabled")
+    private final boolean commentEnabled;
+
+    @JsonProperty("is_liked")
+    private final boolean liked;
+
+    @JsonProperty("is_bookmarked")
+    private final boolean bookmarked;
+
+    @JsonProperty("created_at")
+    private final LocalDateTime createdAt;
+
+    @JsonProperty("images")
+    private final List<String> images;
+
+    @JsonProperty("hashtags")
+    private final List<String> hashtags;
+
+    @JsonProperty("member")
+    private final MemberInfo member;
+
+    private FeedResponse(Post post, List<String> images, List<String> hashtags,
+                         boolean isLiked, boolean isBookmarked, int commentCount) {
+        Member m = post.getMember();
+        this.postId = post.getPostId();
+        this.content = post.getContents();
+        this.likeCount = post.getLikeCount();
+        this.commentCount = commentCount;
+        this.commentEnabled = post.isCommentEnabled();
+        this.liked = isLiked;
+        this.bookmarked = isBookmarked;
+        this.createdAt = post.getCreatedAt();
+        this.images = images;
+        this.hashtags = hashtags;
+        this.member = MemberInfo.from(m);
+    }
+
+    public static FeedResponse of(Post post, List<PostImage> images, List<String> hashtags, boolean isLiked, boolean isBookmarked, int commentCount) {
+        List<String> imageUrls = images.stream().map(PostImage::getImageUrl).toList();
+        return new FeedResponse(post, imageUrls, hashtags, isLiked, isBookmarked, commentCount);
+    }
+
+    @Getter
+    public static class MemberInfo {
+
+        @JsonProperty("member_id")
+        private final Long memberId;
+
+        @JsonProperty("username")
+        private final String username;
+
+        @JsonProperty("image_url")
+        private final String imageUrl;
+
+        private MemberInfo(Long memberId, String username, String imageUrl) {
+            this.memberId = memberId;
+            this.username = username;
+            this.imageUrl = imageUrl;
+        }
+
+        public static MemberInfo from(Member member) {
+            return new MemberInfo(member.getMemberId(), member.getMemberUsername(), member.getImageUrl());
+        }
+    }
+}

--- a/src/main/java/com/instagram/backend/domain/post/repository/PostImageRepository.java
+++ b/src/main/java/com/instagram/backend/domain/post/repository/PostImageRepository.java
@@ -14,4 +14,7 @@ public interface PostImageRepository extends JpaRepository<PostImage, Long> {
     // — 북마크 목록 같은 썸네일 그리드 화면에서 N+1 문제를 막기 위해 사용
     // — sort_order=0인 첫 번째 이미지가 인스타그램의 "대표 썸네일" 역할
     List<PostImage> findByPostPostIdInAndSortOrder(Collection<Long> postIds, int sortOrder);
+
+    // 피드용 — 여러 게시물의 전체 이미지 일괄 조회 (N+1 방지)
+    List<PostImage> findByPostPostIdInOrderBySortOrderAsc(Collection<Long> postIds);
 }

--- a/src/main/java/com/instagram/backend/domain/post/repository/PostLikeRepository.java
+++ b/src/main/java/com/instagram/backend/domain/post/repository/PostLikeRepository.java
@@ -2,11 +2,21 @@ package com.instagram.backend.domain.post.repository;
 
 import com.instagram.backend.domain.post.entity.PostLike;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.Collection;
 import java.util.Optional;
+import java.util.Set;
 
 public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
     Optional<PostLike> findByPostIdAndMemberId(Long postId, Long memberId);
 
     boolean existsByPostIdAndMemberId(Long postId, Long memberId);
+
+    // 피드용 — 내가 좋아요한 postId Set (O(1) 조회로 N+1 방지)
+    @Query("SELECT pl.postId FROM PostLike pl WHERE pl.memberId = :memberId AND pl.postId IN :postIds")
+    Set<Long> findPostIdsByMemberIdAndPostIdIn(
+            @Param("memberId") Long memberId,
+            @Param("postIds") Collection<Long> postIds);
 }

--- a/src/main/java/com/instagram/backend/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/instagram/backend/domain/post/repository/PostRepository.java
@@ -5,6 +5,8 @@ import org.springframework.data.jpa.repository.JpaRepository;// Spring Data JPA 
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import org.springframework.data.domain.Pageable;
+
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -23,4 +25,32 @@ public interface PostRepository extends JpaRepository<Post, Long> {//<다룰 앤
 
     // → 특정 유저의 삭제되지 않은 게시물 수 (프로필의 "게시물 N" 표시용)
     long countByMemberMemberIdAndIsDeletedFalse(Long memberId);
+
+    // 피드 첫 페이지 (cursor 없음) — JOIN FETCH로 N+1 방지
+    @Query("""
+        SELECT DISTINCT p FROM Post p
+        JOIN FETCH p.member
+        WHERE p.isDeleted = false
+          AND (p.member.id IN :followingMemberIds OR p.postId IN :hashtagPostIds)
+        ORDER BY p.postId DESC
+    """)
+    List<Post> findFeedPostsFirst(
+            @Param("followingMemberIds") List<Long> followingMemberIds,
+            @Param("hashtagPostIds") List<Long> hashtagPostIds,
+            Pageable pageable);
+
+    // 피드 다음 페이지 (cursor 있음)
+    @Query("""
+        SELECT DISTINCT p FROM Post p
+        JOIN FETCH p.member
+        WHERE p.isDeleted = false
+          AND (p.member.id IN :followingMemberIds OR p.postId IN :hashtagPostIds)
+          AND p.postId < :cursor
+        ORDER BY p.postId DESC
+    """)
+    List<Post> findFeedPostsWithCursor(
+            @Param("followingMemberIds") List<Long> followingMemberIds,
+            @Param("hashtagPostIds") List<Long> hashtagPostIds,
+            @Param("cursor") Long cursor,
+            Pageable pageable);
 }

--- a/src/main/java/com/instagram/backend/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/instagram/backend/domain/post/repository/PostRepository.java
@@ -31,7 +31,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {//<다룰 앤
         SELECT DISTINCT p FROM Post p
         JOIN FETCH p.member
         WHERE p.isDeleted = false
-          AND (p.member.id IN :followingMemberIds OR p.postId IN :hashtagPostIds)
+          AND (p.member.memberId IN :followingMemberIds OR p.postId IN :hashtagPostIds)
         ORDER BY p.postId DESC
     """)
     List<Post> findFeedPostsFirst(
@@ -44,7 +44,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {//<다룰 앤
         SELECT DISTINCT p FROM Post p
         JOIN FETCH p.member
         WHERE p.isDeleted = false
-          AND (p.member.id IN :followingMemberIds OR p.postId IN :hashtagPostIds)
+          AND (p.member.memberId IN :followingMemberIds OR p.postId IN :hashtagPostIds)
           AND p.postId < :cursor
         ORDER BY p.postId DESC
     """)

--- a/src/main/java/com/instagram/backend/domain/post/service/FeedService.java
+++ b/src/main/java/com/instagram/backend/domain/post/service/FeedService.java
@@ -1,0 +1,132 @@
+package com.instagram.backend.domain.post.service;
+
+import com.instagram.backend.domain.bookmark.repository.BookmarkRepository;
+import com.instagram.backend.domain.comment.repository.CommentRepository;
+import com.instagram.backend.domain.follow.repository.FollowRepository;
+import com.instagram.backend.domain.hashtag.entity.PostHashtag;
+import com.instagram.backend.domain.hashtag.repository.HashtagFollowRepository;
+import com.instagram.backend.domain.hashtag.repository.HashtagRepository;
+import com.instagram.backend.domain.hashtag.repository.PostHashtagRepository;
+import com.instagram.backend.domain.post.dto.response.FeedListResponse;
+import com.instagram.backend.domain.post.dto.response.FeedResponse;
+import com.instagram.backend.domain.post.entity.Post;
+import com.instagram.backend.domain.post.entity.PostImage;
+import com.instagram.backend.domain.post.repository.PostImageRepository;
+import com.instagram.backend.domain.post.repository.PostLikeRepository;
+import com.instagram.backend.domain.post.repository.PostRepository;
+import com.instagram.backend.global.exception.BusinessException;
+import com.instagram.backend.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FeedService {
+
+    private final PostRepository postRepository;
+    private final PostImageRepository postImageRepository;
+    private final PostLikeRepository postLikeRepository;
+    private final BookmarkRepository bookmarkRepository;
+    private final CommentRepository commentRepository;
+    private final FollowRepository followRepository;
+    private final HashtagFollowRepository hashtagFollowRepository;
+    private final PostHashtagRepository postHashtagRepository;
+    private final HashtagRepository hashtagRepository;
+
+    public FeedListResponse getFeed(Long memberId, Long cursor, int size) {
+        if (size < 1 || size > 30) {
+            throw new BusinessException(ErrorCode.INVALID_LIMIT);
+        }
+
+        // 팔로우한 멤버 ID 목록
+        List<Long> followingMemberIds = followRepository.findFollowingIdsByFollowerId(memberId);
+
+        // 팔로우한 해시태그의 게시물 ID 목록
+        List<Long> followedHashtagIds = hashtagFollowRepository.findHashtagIdsByMemberId(memberId);
+        List<Long> hashtagPostIds = followedHashtagIds.isEmpty() ? List.of() : postHashtagRepository.findPostIdsByHashtagIdIn(followedHashtagIds);
+
+        // 팔로우한 사람도 해시태그도 없으면 빈 피드 반환
+        if (followingMemberIds.isEmpty() && hashtagPostIds.isEmpty()) {
+            return FeedListResponse.empty();
+        }
+
+        // 피드 게시물 조회 (size+1 로 다음 페이지 존재 여부 확인)
+        PageRequest pageable = PageRequest.of(0, size + 1);
+        List<Post> rawPosts = (cursor == null) ? postRepository.findFeedPostsFirst(followingMemberIds, hashtagPostIds, pageable) : postRepository.findFeedPostsWithCursor(followingMemberIds, hashtagPostIds, cursor, pageable);
+
+        boolean hasMore = rawPosts.size() > size;
+        List<Post> posts = hasMore ? rawPosts.subList(0, size) : rawPosts;
+        Long nextCursor = hasMore ? posts.get(posts.size() - 1).getPostId() : null;
+
+        if (posts.isEmpty()) {
+            return FeedListResponse.empty();
+        }
+
+        List<Long> postIds = posts.stream().map(Post::getPostId).toList();
+
+        // 이미지 일괄 조회 — ToMany IN 쿼리 + groupingBy Map
+        Map<Long, List<PostImage>> imageMap = postImageRepository
+                .findByPostPostIdInOrderBySortOrderAsc(postIds)
+                .stream()
+                .collect(Collectors.groupingBy(img -> img.getPost().getPostId()));
+
+        // 해시태그 이름 일괄 조회 — ToMany IN 쿼리 + groupingBy Map
+        Map<Long, List<Long>> postToHashtagIds = postHashtagRepository
+                .findByPostIdIn(postIds)
+                .stream()
+                .collect(Collectors.groupingBy(
+                        PostHashtag::getPostId,
+                        Collectors.mapping(PostHashtag::getHashtagId, Collectors.toList())
+                ));
+
+        List<Long> allHashtagIds = postToHashtagIds.values().stream()
+                .flatMap(List::stream).distinct().toList();
+        Map<Long, String> hashtagNameMap = allHashtagIds.isEmpty()
+                ? Map.of()
+                : hashtagRepository.findByHashtagIdIn(allHashtagIds).stream()
+                        .collect(Collectors.toMap(h -> h.getHashtagId(), h -> h.getName()));
+
+        // 좋아요/저장 Set 조회 — O(1) 조회로 N+1 방지
+        Set<Long> likedPostIds = postLikeRepository.findPostIdsByMemberIdAndPostIdIn(memberId, postIds);
+        Set<Long> bookmarkedPostIds = bookmarkRepository.findPostIdsByMemberIdAndPostIdIn(memberId, postIds);
+
+        // 댓글 수 일괄 집계
+        Map<Long, Integer> commentCountMap = commentRepository
+                .countByPostIdInAndIsDeletedFalse(postIds)
+                .stream()
+                .collect(Collectors.toMap(
+                        row -> (Long) row[0],
+                        row -> ((Long) row[1]).intValue()
+                ));
+
+        // 응답 조립
+        List<FeedResponse> feedItems = posts.stream().map(post -> {
+            Long pId = post.getPostId();
+            List<PostImage> images = imageMap.getOrDefault(pId, List.of());
+            List<String> hashtags = postToHashtagIds
+                    .getOrDefault(pId, List.of())
+                    .stream()
+                    .map(hid -> hashtagNameMap.getOrDefault(hid, ""))
+                    .filter(s -> !s.isEmpty())
+                    .toList();
+            return FeedResponse.of(
+                    post,
+                    images,
+                    hashtags,
+                    likedPostIds.contains(pId),
+                    bookmarkedPostIds.contains(pId),
+                    commentCountMap.getOrDefault(pId, 0)
+            );
+        }).toList();
+
+        return FeedListResponse.of(feedItems, nextCursor, hasMore);
+    }
+}

--- a/src/main/java/com/instagram/backend/domain/post/service/FeedService.java
+++ b/src/main/java/com/instagram/backend/domain/post/service/FeedService.java
@@ -14,6 +14,7 @@ import com.instagram.backend.domain.post.entity.PostImage;
 import com.instagram.backend.domain.post.repository.PostImageRepository;
 import com.instagram.backend.domain.post.repository.PostLikeRepository;
 import com.instagram.backend.domain.post.repository.PostRepository;
+import com.instagram.backend.domain.comment.repository.PostCommentCount;
 import com.instagram.backend.global.exception.BusinessException;
 import com.instagram.backend.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -103,8 +104,8 @@ public class FeedService {
                 .countByPostIdInAndIsDeletedFalse(postIds)
                 .stream()
                 .collect(Collectors.toMap(
-                        row -> (Long) row[0],
-                        row -> ((Long) row[1]).intValue()
+                        PostCommentCount::getPostId,
+                        row -> row.getCount().intValue()
                 ));
 
         // 응답 조립

--- a/src/main/java/com/instagram/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/instagram/backend/global/exception/ErrorCode.java
@@ -56,6 +56,7 @@ public enum ErrorCode {
     HASHTAG_NOT_FOUND(404, "존재하지 않는 해시태그입니다."),
     HASHTAG_FOLLOW_NOT_FOUND(404, "해시태그 팔로우 내역이 존재하지 않습니다."),
     MESSAGE_NOT_FOUND(404, "존재하지 않는 메시지입니다."),
+    ALARM_NOT_FOUND(404, "존재하지 않는 알림입니다."),
 
     // 409 - 중복
     DUPLICATE_EMAIL(409, "이미 사용 중인 이메일입니다."),


### PR DESCRIPTION
기존 피드는 팔로우한 사람의 게시물만 보여주었는데
해시테그를 팔로우해도 그 해시태그가 있는 게시물이 보여지도록 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 홈 피드 조회 추가 (GET /api/feed) — 팔로우·관심 해시태그 게시글 통합 제공, 커서 기반 스크롤 페이지네이션 지원
  * 피드 항목에 이미지 목록, 작성자 정보, 좋아요·북마크 상태, 댓글 수, 생성일 포함

* **성능 개선**
  * 다중 게시글 대상 이미지·해시태그·좋아요·북마크·댓글 수를 일괄 조회해 응답 성능 향상

* **유틸**
  * 포스트별 댓글 수 집계 제공 (페이로드에 통합)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->