### PR TITLE
미디어 업로드 URL 발급 API

### DIFF
--- a/src/main/java/com/instagram/backend/domain/media/controller/MediaController.java
+++ b/src/main/java/com/instagram/backend/domain/media/controller/MediaController.java
@@ -7,6 +7,7 @@ import com.instagram.backend.global.dto.ApiResponse;
 import com.instagram.backend.global.security.CustomUserDetails;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -26,6 +27,6 @@ public class MediaController {
     public ResponseEntity<ApiResponse<PresignedUrlResponse>> getPresignedUrl(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @Valid @RequestBody PresignedUrlRequest request) {
-        return ResponseEntity.ok(ApiResponse.success(mediaService.generatePresignedUrl(request), "업로드 URL이 발급되었습니다."));
+        return ResponseEntity.status(HttpStatus.CREATED) .body(ApiResponse.success(mediaService.generatePresignedUrl(request), "업로드 URL이 발급되었습니다."));
     }
 }

--- a/src/main/java/com/instagram/backend/domain/media/controller/MediaController.java
+++ b/src/main/java/com/instagram/backend/domain/media/controller/MediaController.java
@@ -1,0 +1,31 @@
+package com.instagram.backend.domain.media.controller;
+
+import com.instagram.backend.domain.media.dto.request.PresignedUrlRequest;
+import com.instagram.backend.domain.media.dto.response.PresignedUrlResponse;
+import com.instagram.backend.domain.media.service.MediaService;
+import com.instagram.backend.global.dto.ApiResponse;
+import com.instagram.backend.global.security.CustomUserDetails;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/media")
+@RequiredArgsConstructor
+public class MediaController {
+
+    private final MediaService mediaService;
+
+    // Presigned URL 발급 — POST /api/media/upload
+    @PostMapping("/upload")
+    public ResponseEntity<ApiResponse<PresignedUrlResponse>> getPresignedUrl(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestBody PresignedUrlRequest request) {
+        return ResponseEntity.ok(ApiResponse.success(mediaService.generatePresignedUrl(request), "업로드 URL이 발급되었습니다."));
+    }
+}

--- a/src/main/java/com/instagram/backend/domain/media/dto/request/PresignedUrlRequest.java
+++ b/src/main/java/com/instagram/backend/domain/media/dto/request/PresignedUrlRequest.java
@@ -2,6 +2,7 @@ package com.instagram.backend.domain.media.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -16,6 +17,7 @@ public class PresignedUrlRequest {
     private String fileType;
 
     @NotNull
+    @Positive(message = "파일 크기는 1 이상이어야 합니다.")
     private Long fileSize;
 
     @NotBlank

--- a/src/main/java/com/instagram/backend/domain/media/dto/request/PresignedUrlRequest.java
+++ b/src/main/java/com/instagram/backend/domain/media/dto/request/PresignedUrlRequest.java
@@ -1,0 +1,23 @@
+package com.instagram.backend.domain.media.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class PresignedUrlRequest {
+
+    @NotBlank
+    private String fileName;
+
+    @NotBlank
+    private String fileType;
+
+    @NotNull
+    private Long fileSize;
+
+    @NotBlank
+    private String uploadType;
+}

--- a/src/main/java/com/instagram/backend/domain/media/dto/response/PresignedUrlResponse.java
+++ b/src/main/java/com/instagram/backend/domain/media/dto/response/PresignedUrlResponse.java
@@ -1,0 +1,15 @@
+package com.instagram.backend.domain.media.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class PresignedUrlResponse {
+    private final String uploadUrl;
+    private final String mediaUrl;
+    private final String mediaUuid;
+    private final long expiresIn;
+}

--- a/src/main/java/com/instagram/backend/domain/media/enums/UploadType.java
+++ b/src/main/java/com/instagram/backend/domain/media/enums/UploadType.java
@@ -1,0 +1,23 @@
+package com.instagram.backend.domain.media.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum UploadType {
+    POST("posts"),
+    PROFILE("profiles"),
+    STORY("stories"),
+    MESSAGE("messages");
+
+    private final String directory;
+
+    public static boolean isValid(String value) {
+        if (value == null) return false;
+        for (UploadType type : values()) {
+            if (type.name().equals(value)) return true;//enum.name() : enum-> String
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/instagram/backend/domain/media/service/MediaService.java
+++ b/src/main/java/com/instagram/backend/domain/media/service/MediaService.java
@@ -8,6 +8,7 @@ import com.instagram.backend.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
@@ -18,6 +19,7 @@ import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class MediaService {
 
     private final S3Presigner s3Presigner;

--- a/src/main/java/com/instagram/backend/domain/media/service/MediaService.java
+++ b/src/main/java/com/instagram/backend/domain/media/service/MediaService.java
@@ -1,0 +1,73 @@
+package com.instagram.backend.domain.media.service;
+
+import com.instagram.backend.domain.media.dto.request.PresignedUrlRequest;
+import com.instagram.backend.domain.media.dto.response.PresignedUrlResponse;
+import com.instagram.backend.domain.media.enums.UploadType;
+import com.instagram.backend.global.exception.BusinessException;
+import com.instagram.backend.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+
+import java.time.Duration;
+import java.util.Set;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class MediaService {
+
+    private final S3Presigner s3Presigner;
+
+    @Value("${spring.cloud.aws.s3.bucket}")
+    private String bucket;
+
+    @Value("${spring.cloud.aws.region.static}")
+    private String region;
+
+    @Value("${media.presigned-url-expiration}")
+    private long expiresIn;
+
+    private static final Set<String> ALLOWED_TYPES = Set.of(
+            "image/jpeg", "image/png", "image/gif", "image/webp"
+    );
+    private static final long MAX_FILE_SIZE = 10_485_760L; // 10MB
+
+    public PresignedUrlResponse generatePresignedUrl(PresignedUrlRequest request) {
+        if (!ALLOWED_TYPES.contains(request.getFileType())) {
+            throw new BusinessException(ErrorCode.INVALID_FILE_TYPE);
+        }
+        if (request.getFileSize() > MAX_FILE_SIZE) {
+            throw new BusinessException(ErrorCode.EXCEED_FILE_SIZE);
+        }
+        if (!UploadType.isValid(request.getUploadType())) {
+            throw new BusinessException(ErrorCode.INVALID_UPLOAD_TYPE);
+        }
+
+        UploadType uploadType = UploadType.valueOf(request.getUploadType());
+        String uuid = UUID.randomUUID().toString();
+        String objectKey = uploadType.getDirectory() + "/" + uuid + "_" + request.getFileName();
+
+        PutObjectPresignRequest presignRequest = PutObjectPresignRequest.builder()
+                .signatureDuration(Duration.ofSeconds(expiresIn))
+                .putObjectRequest(r -> r
+                        .bucket(bucket)
+                        .key(objectKey)
+                        .contentType(request.getFileType())
+                )
+                .build();
+
+        PresignedPutObjectRequest presigned = s3Presigner.presignPutObject(presignRequest);
+        String mediaUrl = "https://" + bucket + ".s3." + region + ".amazonaws.com/" + objectKey;
+
+        return PresignedUrlResponse.builder()
+                .uploadUrl(presigned.url().toString())
+                .mediaUrl(mediaUrl)
+                .mediaUuid(uuid)
+                .expiresIn(expiresIn)
+                .build();
+    }
+}

--- a/src/main/java/com/instagram/backend/domain/media/service/MediaService.java
+++ b/src/main/java/com/instagram/backend/domain/media/service/MediaService.java
@@ -35,6 +35,7 @@ public class MediaService {
             "image/jpeg", "image/png", "image/gif", "image/webp"
     );
     private static final long MAX_FILE_SIZE = 10_485_760L; // 10MB
+    private static final int MAX_FILENAME_LENGTH = 100;
 
     public PresignedUrlResponse generatePresignedUrl(PresignedUrlRequest request) {
         if (!ALLOWED_TYPES.contains(request.getFileType())) {
@@ -49,7 +50,7 @@ public class MediaService {
 
         UploadType uploadType = UploadType.valueOf(request.getUploadType());
         String uuid = UUID.randomUUID().toString();
-        String objectKey = uploadType.getDirectory() + "/" + uuid + "_" + request.getFileName();
+        String objectKey = uploadType.getDirectory() + "/" + uuid + "_" + sanitizeFileName(request.getFileName());
 
         PutObjectPresignRequest presignRequest = PutObjectPresignRequest.builder()
                 .signatureDuration(Duration.ofSeconds(expiresIn))
@@ -69,5 +70,18 @@ public class MediaService {
                 .mediaUuid(uuid)
                 .expiresIn(expiresIn)
                 .build();
+    }
+
+    private String sanitizeFileName(String original) {
+        if (original == null || original.isBlank()) return "file";
+
+        String name = original.strip();
+        name = name.replaceAll("[^a-zA-Z0-9._-]", "_");  // 허용 문자 외 치환
+        name = name.replaceAll("\\.{2,}", ".");            // 연속 점 제거 (..)
+        name = name.replaceAll("^[/._-]+", "");           // 앞쪽 슬래시·점·대시 제거
+        if (name.length() > MAX_FILENAME_LENGTH) {
+            name = name.substring(0, MAX_FILENAME_LENGTH);
+        }
+        return name.isBlank() ? "file" : name;
     }
 }

--- a/src/main/java/com/instagram/backend/global/config/S3Config.java
+++ b/src/main/java/com/instagram/backend/global/config/S3Config.java
@@ -1,0 +1,23 @@
+package com.instagram.backend.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+@Configuration
+public class S3Config {
+
+    @Value("${spring.cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public S3Presigner s3Presigner(AwsCredentialsProvider credentialsProvider) {
+        return S3Presigner.builder()
+                .region(Region.of(region))
+                .credentialsProvider(credentialsProvider)
+                .build();
+    }
+}

--- a/src/main/java/com/instagram/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/instagram/backend/global/exception/ErrorCode.java
@@ -24,6 +24,9 @@ public enum ErrorCode {
     INVALID_SEARCH_QUERY(400, "검색어는 1자 이상 입력해주세요."),
     INVALID_DTYPE(400, "올바르지 않은 메시지 타입입니다."),
     MISSING_MESSAGE_CONTENT(400, "메시지 내용을 입력해주세요."),
+    INVALID_FILE_TYPE(400, "지원하지 않는 파일 형식입니다."),
+    EXCEED_FILE_SIZE(400, "파일 크기는 10MB를 초과할 수 없습니다."),
+    INVALID_UPLOAD_TYPE(400, "올바르지 않은 업로드 타입입니다."),
 
     // 401 - 인증 오류
     UNAUTHORIZED(401, "로그인이 필요합니다."),

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -46,6 +46,9 @@ management:
     mail:
       enabled: false   # 로컬에서 Gmail 인증 없이 실행 시 비활성화
 
+media:
+  presigned-url-expiration: 300
+
 springdoc:
   swagger-ui:
     path: /swagger-ui.html


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 미디어 파일 업로드 기능이 추가되었습니다.
  * 포스트, 프로필, 스토리, 메시지 등 다양한 업로드 타입을 지원합니다.
  * 파일 형식 검증 및 최대 10MB 파일 크기 제한이 적용됩니다.
  * 업로드용 안전한 사전 서명 URL(임시 업로드 링크)이 발급되며 만료 시간(기본 300초)이 적용됩니다.
  
Presigned URL 방식(직접 업로드) 사용
- 과정 : 클라이언트 <-> 벡엔드 서버(URL만 발급), 클라이언트 -> S3 저장소(파일 전송)
- 장점 : 백엔드는 무거운 이미지 대신 URL만 발급, 무거운 파일 전송은 클라와 S3이 직접 주고 받음 => 서버 자원 아낄 수 있다.

전통적이였다면?
- 과정: 클라이언트 → 백엔드 서버 → S3 저장소
- 파일 올릴 때 서버에 메모리와 CPU를 많이 소모함 


<!-- end of auto-generated comment: release notes by coderabbit.ai -->