### PR TITLE
57 feat api get search hashtags

### DIFF
--- a/src/main/java/com/instagram/backend/domain/hashtag/repository/HashtagRepository.java
+++ b/src/main/java/com/instagram/backend/domain/hashtag/repository/HashtagRepository.java
@@ -1,7 +1,10 @@
 package com.instagram.backend.domain.hashtag.repository;
 
 import com.instagram.backend.domain.hashtag.entity.Hashtag;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -13,5 +16,22 @@ public interface HashtagRepository extends JpaRepository<Hashtag, Long> {
     List<Hashtag> findByNameIn(List<String> names);
     // ID 목록으로 일괄 조회
     List<Hashtag> findByHashtagIdIn(List<Long> hashtagIds);
+
+    /*
+      해시태그 LIKE 검색 — GET /api/search/hashtags
+
+      정책:
+        — name LIKE '%q%' 로 부분 일치 검색
+        — 정렬: postCount DESC (인기순) → name ASC (보조)
+        — ESCAPE '\\' 절: 서비스 레이어에서 '%', '_', '\' 를 이스케이프한 검색어를 받아
+          LIKE 와일드카드로 해석되는 것을 차단 (LIKE 패턴 인젝션 방어)
+
+      Pageable:
+        — limit 만 사용 (offset 0 고정). 추후 커서 페이징 도입 시 메서드 추가
+    */
+    @Query("SELECT h FROM Hashtag h " +
+            "WHERE h.name LIKE CONCAT('%', :q, '%') ESCAPE '\\' " +
+            "ORDER BY h.postCount DESC, h.name ASC")
+    List<Hashtag> searchByName(@Param("q") String q, Pageable pageable);
 
 }

--- a/src/main/java/com/instagram/backend/domain/hashtag/repository/HashtagRepository.java
+++ b/src/main/java/com/instagram/backend/domain/hashtag/repository/HashtagRepository.java
@@ -33,5 +33,4 @@ public interface HashtagRepository extends JpaRepository<Hashtag, Long> {
             "WHERE h.name LIKE CONCAT('%', :q, '%') ESCAPE '\\' " +
             "ORDER BY h.postCount DESC, h.name ASC")
     List<Hashtag> searchByName(@Param("q") String q, Pageable pageable);
-
 }

--- a/src/main/java/com/instagram/backend/domain/search/controller/SearchController.java
+++ b/src/main/java/com/instagram/backend/domain/search/controller/SearchController.java
@@ -1,5 +1,6 @@
 package com.instagram.backend.domain.search.controller;
 
+import com.instagram.backend.domain.search.dto.response.HashtagSearchResponse;
 import com.instagram.backend.domain.search.dto.response.UserSearchResponse;
 import com.instagram.backend.domain.search.service.SearchService;
 import com.instagram.backend.global.dto.ApiResponse;
@@ -54,6 +55,36 @@ public class SearchController {
 
         return ResponseEntity.ok(
                 ApiResponse.success(response, "유저 검색에 성공하였습니다.")
+        );
+    }
+
+    /*
+      GET /api/search/hashtags — 해시태그 검색
+
+      쿼리 파라미터:
+        — q (필수): 검색어. Hashtag.name 에 대해 LIKE 검색 ('#' 접두사 자동 제거)
+        — limit (선택): 결과 수. 기본 10, 최대 50
+
+      응답:
+        — hashtags 배열 안에 hashtag_id, name, post_count
+        — 정렬: post_count DESC, name ASC (인기순 → 이름순)
+        — 검색 결과가 없으면 빈 배열 반환 (404가 아닌 200 + 빈 리스트)
+
+      참고:
+        — 유저 검색의 is_following 같은 관계 필드는 명세 외 스코프이므로 제외
+    */
+    @GetMapping("/hashtags")
+    public ResponseEntity<ApiResponse<HashtagSearchResponse>> searchHashtags(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            // required=false 이유는 searchUsers 와 동일 — 명세서 정의 에러코드를 서비스에서 직접 반환
+            @RequestParam(required = false) String q,
+            @RequestParam(required = false) Integer limit) {
+
+        HashtagSearchResponse response = searchService.searchHashtags(
+                userDetails.getMemberId(), q, limit);
+
+        return ResponseEntity.ok(
+                ApiResponse.success(response, "해시태그 검색에 성공하였습니다.")
         );
     }
 }

--- a/src/main/java/com/instagram/backend/domain/search/dto/response/HashtagSearchResponse.java
+++ b/src/main/java/com/instagram/backend/domain/search/dto/response/HashtagSearchResponse.java
@@ -1,0 +1,57 @@
+package com.instagram.backend.domain.search.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.instagram.backend.domain.hashtag.entity.Hashtag;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+/*
+  HashtagSearchResponse — 해시태그 검색 응답 DTO
+
+  설계:
+    — 명세서의 응답 구조를 그대로 반영 (hashtags 배열)
+    — 각 항목: hashtag_id, name, post_count
+    — 유저 검색의 is_following 같은 관계 필드는 의도적으로 제외
+      (명세 외 추가는 스코프 침범. 추후 클라이언트 요구사항 생기면 재논의)
+
+  of() 팩토리 메서드:
+    — Hashtag 엔티티 리스트를 받아 DTO 변환
+    — 정렬은 Repository 의 ORDER BY 가 보장하므로 추가 정렬 없음
+*/
+@Getter
+@Builder
+public class HashtagSearchResponse {
+
+    @JsonProperty("hashtags")
+    private final List<HashtagInfo> hashtags;
+
+    @Getter
+    @Builder
+    public static class HashtagInfo {
+
+        @JsonProperty("hashtag_id")
+        private final Long hashtagId;
+
+        @JsonProperty("name")
+        private final String name;
+
+        @JsonProperty("post_count")
+        private final int postCount;
+    }
+
+    public static HashtagSearchResponse of(List<Hashtag> hashtags) {
+        List<HashtagInfo> hashtagInfos = hashtags.stream()
+                .map(h -> HashtagInfo.builder()
+                        .hashtagId(h.getHashtagId())
+                        .name(h.getName())
+                        .postCount(h.getPostCount())
+                        .build())
+                .toList();
+
+        return HashtagSearchResponse.builder()
+                .hashtags(hashtagInfos)
+                .build();
+    }
+}

--- a/src/main/java/com/instagram/backend/domain/search/service/SearchService.java
+++ b/src/main/java/com/instagram/backend/domain/search/service/SearchService.java
@@ -19,6 +19,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+
 /*
   SearchService — 검색 도메인 비즈니스 로직
 
@@ -101,18 +102,21 @@ public class SearchService {
         — '#' 접두사 처리 단계 추가
         — is_following 같은 관계 필드 없음 (명세 외 스코프)
         — 본인 제외 같은 필터 없음 (해시태그는 작성자 개념 없음)
+
+      myMemberId 파라미터:
+        — 현재 본 메서드 내부 로직에서는 미사용
+        — searchUsers 와 시그너처를 통일하기 위해 유지
+        — 향후 개인화(차단/숨김 해시태그, 개인 추천 가중치 등) 확장 시 활용 예정
     */
     public HashtagSearchResponse searchHashtags(Long myMemberId, String q, Integer limit) {
         String stripped = stripHashPrefix(q);
         String escaped = escapeLikePattern(validateQuery(stripped));
         int size = validateLimit(limit);
 
+        // searchByName 결과가 비어 있어도 HashtagSearchResponse.of 가 정상 처리하므로
+        // 별도 early-return 분기 불필요 (searchUsers 와는 달리 후속 IN 쿼리가 없음)
         List<Hashtag> hashtags = hashtagRepository.searchByName(
                 escaped, PageRequest.of(0, size));
-
-        if (hashtags.isEmpty()) {
-            return HashtagSearchResponse.of(Collections.emptyList());
-        }
 
         return HashtagSearchResponse.of(hashtags);
     }
@@ -162,6 +166,9 @@ public class SearchService {
           의도치 않게 전체 row가 반환될 수 있음 (정보 열거 위험)
         — '\' 를 가장 먼저 이스케이프해야 이중 이스케이프 충돌 방지
         — JPQL 쿼리의 ESCAPE '\\' 절과 함께 동작
+
+      호출 전 validateQuery() 통과를 가정하므로 null 검사를 별도 수행하지 않음.
+      추후 외부에서 직접 호출되는 일이 생긴다면 null/blank 가드 추가 필요.
     */
     private String escapeLikePattern(String q) {
         return q
@@ -173,7 +180,8 @@ public class SearchService {
     /*
       해시태그 검색어의 '#' 접두사 제거
         — 사용자가 '#음식' 으로 검색해도 '음식' 으로 검색한 것과 동일하게 처리
-        — null 안전 (validateQuery 에서 null 처리)
+        — '#' 분기와 비분기 모두 trim 된 값을 반환하여 동작 일관성 유지
+        — null 안전 (validateQuery 에서 null 재검증)
     */
     private String stripHashPrefix(String q) {
         if (q == null) return null;
@@ -181,6 +189,6 @@ public class SearchService {
         if (trimmed.startsWith("#")) {
             return trimmed.substring(1);
         }
-        return q;
+        return trimmed;
     }
 }

--- a/src/main/java/com/instagram/backend/domain/search/service/SearchService.java
+++ b/src/main/java/com/instagram/backend/domain/search/service/SearchService.java
@@ -1,8 +1,11 @@
 package com.instagram.backend.domain.search.service;
 
 import com.instagram.backend.domain.follow.repository.FollowRepository;
+import com.instagram.backend.domain.hashtag.entity.Hashtag;
+import com.instagram.backend.domain.hashtag.repository.HashtagRepository;
 import com.instagram.backend.domain.member.entity.Member;
 import com.instagram.backend.domain.member.repository.MemberRepository;
+import com.instagram.backend.domain.search.dto.response.HashtagSearchResponse;
 import com.instagram.backend.domain.search.dto.response.UserSearchResponse;
 import com.instagram.backend.global.exception.BusinessException;
 import com.instagram.backend.global.exception.ErrorCode;
@@ -21,12 +24,22 @@ import java.util.Set;
 
   담당 기능:
     — searchUsers: GET /api/search/users
+    — searchHashtags: GET /api/search/hashtags
 
   설계 원칙:
-    — 검색어(q)로 username과 name을 LIKE 검색 (OR 조건)
-    — 본인 제외, 소프트 삭제 제외
-    — is_following 판단은 IN 배치 조회로 N+1 회피
-      (검색 결과 memberId 목록 → FollowRepository.findFollowingIdsAmong() 한 번 호출)
+    — 검색어(q)에 LIKE 와일드카드 이스케이프 적용 (정보 열거 방지)
+    — limit 정규화 (기본 10, 최대 50)
+    — 결과 비어있으면 빈 응답 즉시 반환 (IN 빈 컬렉션 방지 등)
+    — 관계 정보(팔로우 여부)는 IN 배치 조회로 N+1 회피
+
+  헬퍼 메서드 추출:
+    — validateQuery / validateLimit / escapeLikePattern 은 두 검색에서 공유
+    — 추후 검색 도메인 확장(게시물·장소 등) 시 별도 유틸 클래스로 분리 고려
+      (현재는 도메인 외부 노출 필요성이 없어 private 유지)
+
+  TODO:
+    — LIKE 검색은 인덱스를 못 타므로 데이터가 커지면 풀 스캔. 운영 단계에서는
+      Elasticsearch 등 검색엔진 도입 검토. 학습 프로젝트 MVP 수준에서는 LIKE 로 충분.
 */
 @Service
 @RequiredArgsConstructor
@@ -38,6 +51,7 @@ public class SearchService {
 
     private final MemberRepository memberRepository;
     private final FollowRepository followRepository;
+    private final HashtagRepository hashtagRepository;
 
     /*
       유저 검색 — GET /api/search/users
@@ -48,39 +62,11 @@ public class SearchService {
         3) Member LIKE 검색 (username OR name, 본인 제외, isDeleted=false)
         4) 검색 결과 memberId로 팔로우 여부 배치 조회
         5) 응답 DTO 조립
-
-      검색 방식:
-        — LIKE '%q%' → DB 인덱스를 못 타므로 풀 스캔
-        — 대규모 서비스에서는 Elasticsearch 같은 검색 엔진이 필요하지만
-          학습 목적 프로젝트에서는 LIKE로 충분 (MVP)
     */
     public UserSearchResponse searchUsers(Long myMemberId, String q, Integer limit) {
-        // 1) 검색어 검증
-        if (q == null) {
-            throw new BusinessException(ErrorCode.MISSING_REQUIRED_FIELD);
-        }
-        String trimmed = q.trim();
-        if (trimmed.isEmpty()) {
-            throw new BusinessException(ErrorCode.INVALID_SEARCH_QUERY);
-        }
+        String escaped = escapeLikePattern(validateQuery(q));
+        int size = validateLimit(limit);
 
-        // LIKE 와일드카드 이스케이프
-        //   — 사용자가 '%' 또는 '_'를 검색어에 포함하면 LIKE 패턴으로 해석되어
-        //     의도치 않게 전체 회원이 반환될 수 있음 (정보 열거 위험)
-        //   — '%'와 '_'를 이스케이프하여 리터럴 문자로 취급하게 함
-        //   — JPQL 쿼리에 ESCAPE '\\' 절과 함께 동작
-        String escaped = trimmed
-                .replace("\\", "\\\\")
-                .replace("%", "\\%")
-                .replace("_", "\\_");
-
-        // 2) limit 검증
-        int size = (limit == null) ? DEFAULT_LIMIT : limit;
-        if (size < 1 || size > MAX_LIMIT) {
-            throw new BusinessException(ErrorCode.INVALID_LIMIT);
-        }
-
-        // 3) LIKE 검색 (본인 제외, 소프트 삭제 제외)
         List<Member> members = memberRepository.searchByUsernameOrName(
                 myMemberId, escaped, PageRequest.of(0, size));
 
@@ -90,14 +76,111 @@ public class SearchService {
             return UserSearchResponse.of(Collections.emptyList(), Collections.emptySet());
         }
 
-        // 4) 팔로우 여부 배치 조회 (N+1 회피)
-        //    — 검색 결과의 memberId를 모아서 한 번의 IN 쿼리로 처리
-        //    — 반환값은 내가 팔로우 중인 memberId 목록 → Set으로 변환하여 O(1) lookup
+        // 팔로우 여부 배치 조회 (N+1 회피)
+        //   — 검색 결과 memberId 를 모아서 한 번의 IN 쿼리로 처리
+        //   — 반환값을 Set 으로 변환하여 O(1) lookup
         List<Long> memberIds = members.stream().map(Member::getMemberId).toList();
         Set<Long> followingIds = new HashSet<>(
                 followRepository.findFollowingIdsAmong(myMemberId, memberIds));
 
-        // 5) 응답 조립
         return UserSearchResponse.of(members, followingIds);
+    }
+
+    /*
+      해시태그 검색 — GET /api/search/hashtags
+
+      처리 순서:
+        1) '#' 접두사 제거 ('#음식' === '음식')
+        2) 검색어 검증 (null → MISSING_REQUIRED_FIELD, blank → INVALID_SEARCH_QUERY)
+        3) LIKE 와일드카드 이스케이프
+        4) limit 정규화
+        5) Hashtag LIKE 검색 (postCount DESC, name ASC)
+        6) 응답 DTO 조립
+
+      유저 검색과의 차이:
+        — '#' 접두사 처리 단계 추가
+        — is_following 같은 관계 필드 없음 (명세 외 스코프)
+        — 본인 제외 같은 필터 없음 (해시태그는 작성자 개념 없음)
+    */
+    public HashtagSearchResponse searchHashtags(Long myMemberId, String q, Integer limit) {
+        String stripped = stripHashPrefix(q);
+        String escaped = escapeLikePattern(validateQuery(stripped));
+        int size = validateLimit(limit);
+
+        List<Hashtag> hashtags = hashtagRepository.searchByName(
+                escaped, PageRequest.of(0, size));
+
+        if (hashtags.isEmpty()) {
+            return HashtagSearchResponse.of(Collections.emptyList());
+        }
+
+        return HashtagSearchResponse.of(hashtags);
+    }
+
+    /*
+      ─── 공통 헬퍼 메서드 ───
+
+      검색 도메인 내부에서 두 endpoint 가 공유하는 검증/정규화 로직.
+      외부 도메인에서는 사용하지 않으므로 private 유지.
+      추후 검색 대상이 늘어나거나 다른 도메인에서 동일 검증이 필요해지면
+      별도 SearchUtils / QueryValidator 클래스로 분리 고려.
+    */
+
+    /*
+      검색어 검증
+        — null  → MISSING_REQUIRED_FIELD (요청 필수 항목 미입력)
+        — blank → INVALID_SEARCH_QUERY (공백만 입력)
+      검증 통과 시 trim 된 문자열 반환
+    */
+    private String validateQuery(String q) {
+        if (q == null) {
+            throw new BusinessException(ErrorCode.MISSING_REQUIRED_FIELD);
+        }
+        String trimmed = q.trim();
+        if (trimmed.isEmpty()) {
+            throw new BusinessException(ErrorCode.INVALID_SEARCH_QUERY);
+        }
+        return trimmed;
+    }
+
+    /*
+      limit 검증
+        — null → 기본값(10)
+        — 1 ~ 50 범위 외 → INVALID_LIMIT
+    */
+    private int validateLimit(Integer limit) {
+        int size = (limit == null) ? DEFAULT_LIMIT : limit;
+        if (size < 1 || size > MAX_LIMIT) {
+            throw new BusinessException(ErrorCode.INVALID_LIMIT);
+        }
+        return size;
+    }
+
+    /*
+      LIKE 와일드카드 이스케이프
+        — 사용자가 '%' 또는 '_'를 검색어에 포함하면 LIKE 패턴으로 해석되어
+          의도치 않게 전체 row가 반환될 수 있음 (정보 열거 위험)
+        — '\' 를 가장 먼저 이스케이프해야 이중 이스케이프 충돌 방지
+        — JPQL 쿼리의 ESCAPE '\\' 절과 함께 동작
+    */
+    private String escapeLikePattern(String q) {
+        return q
+                .replace("\\", "\\\\")
+                .replace("%", "\\%")
+                .replace("_", "\\_");
+    }
+
+    /*
+      해시태그 검색어의 '#' 접두사 제거
+        — 사용자가 '#음식' 으로 검색해도 '음식' 으로 검색한 것과 동일하게 처리
+        — null 안전 (validateQuery 에서 null 처리)
+    */
+    private String stripHashPrefix(String q) {
+        if (q == null) return null;
+        String trimmed = q.trim();
+        if (trimmed.startsWith("#")) {
+            return trimmed.substring(1);
+        }
+        return q;
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 해시태그 검색 기능 추가: 사용자는 이제 검색 API를 통해 해시태그를 검색할 수 있습니다. 검색 결과는 게시글 수 기준으로 정렬되며, 검색어는 부분 일치로 처리됩니다.

* **리팩토링**
  * 검색 서비스의 쿼리 검증 및 정규화 로직을 개선하여 코드 중복을 제거하고 유지보수성을 향상시켰습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->