### PR TITLE
feat: 알람 Redis 연동 + 스토리/메시지 알람 구현

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,14 @@ services:
       interval: 10s
       retries: 3
 
+  # ── Redis GUI ─────────────────────────────────────────
+  redisinsight:
+    image: redis/redisinsight:latest
+    ports:
+      - "5540:5540"
+    depends_on:
+      - redis
+
   # ── Monitoring ────────────────────────────────────────
   prometheus:
     image: prom/prometheus:v3.2.0

--- a/src/main/java/com/instagram/backend/domain/alarm/entity/Alarm.java
+++ b/src/main/java/com/instagram/backend/domain/alarm/entity/Alarm.java
@@ -91,6 +91,29 @@ public class Alarm extends BaseTimeEntity {
                 .build();
     }
 
+    public static Alarm ofStoryView(Long targetMemberId, Long senderMemberId, Long storyId) {
+        Objects.requireNonNull(storyId, "storyId must not be null for STORY_VIEW");
+        return Alarm.builder()
+                .alarmType(AlarmType.STORY_VIEW)
+                .targetMemberId(targetMemberId)
+                .senderMemberId(senderMemberId)
+                .referenceId(storyId)
+                .build();
+    }
+
+    public static Alarm ofMessage(Long targetMemberId, Long senderMemberId,
+                                   Long messageId, Long chatRoomId) {
+        Objects.requireNonNull(messageId, "messageId must not be null for MESSAGE");
+        Objects.requireNonNull(chatRoomId, "chatRoomId must not be null for MESSAGE");
+        return Alarm.builder()
+                .alarmType(AlarmType.MESSAGE)
+                .targetMemberId(targetMemberId)
+                .senderMemberId(senderMemberId)
+                .referenceId(messageId)
+                .secondaryReferenceId(chatRoomId)
+                .build();
+    }
+
     // 최초 읽음 시각을 보존 — 중복 호출 시 덮어쓰지 않음
     public void markAsRead() {
         if (this.readAt == null) {

--- a/src/main/java/com/instagram/backend/domain/alarm/entity/Alarm.java
+++ b/src/main/java/com/instagram/backend/domain/alarm/entity/Alarm.java
@@ -11,7 +11,10 @@ import java.time.LocalDateTime;
 import java.util.Objects;
 
 @Entity
-@Table(name = "alarms")
+@Table(name = "alarms", indexes = {
+        @Index(name = "idx_alarm_target_member_id", columnList = "target_member_id"),
+        @Index(name = "idx_alarm_target_unread",   columnList = "target_member_id, read_at")
+})
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Alarm extends BaseTimeEntity {

--- a/src/main/java/com/instagram/backend/domain/alarm/entity/AlarmType.java
+++ b/src/main/java/com/instagram/backend/domain/alarm/entity/AlarmType.java
@@ -4,5 +4,7 @@ public enum AlarmType {
     FOLLOW,
     POST_LIKE,
     COMMENT,
-    COMMENT_LIKE
+    COMMENT_LIKE,
+    STORY_VIEW,
+    MESSAGE
 }

--- a/src/main/java/com/instagram/backend/domain/alarm/service/AlarmService.java
+++ b/src/main/java/com/instagram/backend/domain/alarm/service/AlarmService.java
@@ -73,10 +73,11 @@ public class AlarmService {
                 .map(Alarm::getSenderMemberId)
                 .collect(Collectors.toSet());
 
-        Map<Long, Member> senderMap = memberRepository.findAllById(senderIds).stream()
+        Map<Long, Member> senderMap = memberRepository.findByMemberIdInAndIsDeletedFalse(senderIds).stream()
                 .collect(Collectors.toMap(Member::getMemberId, m -> m));
 
         List<AlarmResponse> content = result.stream()
+                .filter(alarm -> senderMap.containsKey(alarm.getSenderMemberId()))
                 .map(alarm -> AlarmResponse.of(alarm, senderMap.get(alarm.getSenderMemberId())))
                 .collect(Collectors.toList());
 

--- a/src/main/java/com/instagram/backend/domain/alarm/service/AlarmService.java
+++ b/src/main/java/com/instagram/backend/domain/alarm/service/AlarmService.java
@@ -9,7 +9,9 @@ import com.instagram.backend.global.dto.CursorPageResponse;
 import com.instagram.backend.global.exception.BusinessException;
 import com.instagram.backend.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,15 +23,24 @@ import java.util.stream.Collectors;
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
+@Slf4j
 public class AlarmService {
+
+    private static final String UNREAD_KEY_PREFIX = "alarm:unread:";
 
     private final AlarmRepository alarmRepository;
     private final MemberRepository memberRepository;
+    private final StringRedisTemplate redisTemplate;
 
     @Transactional
     public void createAlarm(Alarm alarm) {
         if (alarm.getTargetMemberId().equals(alarm.getSenderMemberId())) return;
         alarmRepository.save(alarm);
+        try {
+            redisTemplate.opsForValue().increment(UNREAD_KEY_PREFIX + alarm.getTargetMemberId());
+        } catch (Exception e) {
+            log.warn("Redis INCR 실패 (alarm:unread:{}): {}", alarm.getTargetMemberId(), e.getMessage());
+        }
     }
 
     public CursorPageResponse<AlarmResponse> getAlarms(Long memberId, String cursor, int limit) {
@@ -81,10 +92,31 @@ public class AlarmService {
         if (!alarm.getTargetMemberId().equals(memberId)) {
             throw new BusinessException(ErrorCode.ALARM_ACCESS_DENIED);
         }
+        boolean wasUnread = alarm.getReadAt() == null;
         alarm.markAsRead();
+        if (wasUnread) {
+            try {
+                String key = UNREAD_KEY_PREFIX + memberId;
+                Long current = redisTemplate.opsForValue().decrement(key);
+                if (current != null && current < 0) {
+                    redisTemplate.opsForValue().set(key, "0");
+                }
+            } catch (Exception e) {
+                log.warn("Redis DECR 실패 (alarm:unread:{}): {}", memberId, e.getMessage());
+            }
+        }
     }
 
     public long getUnreadCount(Long memberId) {
-        return alarmRepository.countByTargetMemberIdAndReadAtIsNull(memberId);
+        try {
+            String value = redisTemplate.opsForValue().get(UNREAD_KEY_PREFIX + memberId);
+            if (value != null) return Long.parseLong(value);
+            long count = alarmRepository.countByTargetMemberIdAndReadAtIsNull(memberId);
+            redisTemplate.opsForValue().set(UNREAD_KEY_PREFIX + memberId, String.valueOf(count));
+            return count;
+        } catch (Exception e) {
+            log.warn("Redis 조회 실패 (alarm:unread:{}), DB fallback: {}", memberId, e.getMessage());
+            return alarmRepository.countByTargetMemberIdAndReadAtIsNull(memberId);
+        }
     }
 }

--- a/src/main/java/com/instagram/backend/domain/alarm/service/AlarmService.java
+++ b/src/main/java/com/instagram/backend/domain/alarm/service/AlarmService.java
@@ -15,6 +15,7 @@ import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -27,6 +28,7 @@ import java.util.stream.Collectors;
 public class AlarmService {
 
     private static final String UNREAD_KEY_PREFIX = "alarm:unread:";
+    private static final Duration UNREAD_TTL = Duration.ofDays(30);
 
     private final AlarmRepository alarmRepository;
     private final MemberRepository memberRepository;
@@ -37,7 +39,9 @@ public class AlarmService {
         if (alarm.getTargetMemberId().equals(alarm.getSenderMemberId())) return;
         alarmRepository.save(alarm);
         try {
-            redisTemplate.opsForValue().increment(UNREAD_KEY_PREFIX + alarm.getTargetMemberId());
+            String key = UNREAD_KEY_PREFIX + alarm.getTargetMemberId();
+            redisTemplate.opsForValue().increment(key);
+            redisTemplate.expire(key, UNREAD_TTL);
         } catch (Exception e) {
             log.warn("Redis INCR 실패 (alarm:unread:{}): {}", alarm.getTargetMemberId(), e.getMessage());
         }
@@ -100,7 +104,7 @@ public class AlarmService {
                 String key = UNREAD_KEY_PREFIX + memberId;
                 Long current = redisTemplate.opsForValue().decrement(key);
                 if (current != null && current < 0) {
-                    redisTemplate.opsForValue().set(key, "0");
+                    redisTemplate.opsForValue().set(key, "0", UNREAD_TTL);
                 }
             } catch (Exception e) {
                 log.warn("Redis DECR 실패 (alarm:unread:{}): {}", memberId, e.getMessage());
@@ -113,7 +117,7 @@ public class AlarmService {
             String value = redisTemplate.opsForValue().get(UNREAD_KEY_PREFIX + memberId);
             if (value != null) return Long.parseLong(value);
             long count = alarmRepository.countByTargetMemberIdAndReadAtIsNull(memberId);
-            redisTemplate.opsForValue().set(UNREAD_KEY_PREFIX + memberId, String.valueOf(count));
+            redisTemplate.opsForValue().set(UNREAD_KEY_PREFIX + memberId, String.valueOf(count), UNREAD_TTL);
             return count;
         } catch (Exception e) {
             log.warn("Redis 조회 실패 (alarm:unread:{}), DB fallback: {}", memberId, e.getMessage());

--- a/src/main/java/com/instagram/backend/domain/chat/repository/ChatRoomMemberRepository.java
+++ b/src/main/java/com/instagram/backend/domain/chat/repository/ChatRoomMemberRepository.java
@@ -34,6 +34,10 @@ public interface ChatRoomMemberRepository extends JpaRepository<ChatRoomMember, 
     // → 내가 속한 room들의 "다른 참여자" 정보를 한 번에 가져올 때 사용
     List<ChatRoomMember> findByChatRoomIdIn(Collection<Long> chatRoomIds);
 
+    // 단일 채팅방의 전체 참여자 목록 조회
+    // SELECT * FROM chat_room_members WHERE chat_room_id = ?
+    List<ChatRoomMember> findByChatRoomId(Long chatRoomId);
+
     /*
       1:1 DM 채팅방 중복 체크용 쿼리
 

--- a/src/main/java/com/instagram/backend/domain/comment/service/CommentService.java
+++ b/src/main/java/com/instagram/backend/domain/comment/service/CommentService.java
@@ -1,7 +1,5 @@
 package com.instagram.backend.domain.comment.service;
 
-import com.instagram.backend.domain.alarm.entity.Alarm;
-import com.instagram.backend.domain.alarm.service.AlarmService;
 import com.instagram.backend.domain.comment.dto.request.CommentCreateRequest;
 import com.instagram.backend.domain.comment.dto.response.CommentCreateResponse;
 import com.instagram.backend.domain.comment.dto.response.CommentListResponse;
@@ -31,7 +29,6 @@ public class CommentService {
     private final CommentRepository commentRepository;
     private final MemberRepository memberRepository;
     private final PostRepository postRepository;
-    private final AlarmService alarmService;
 
     //댓글 생성
     @Transactional
@@ -66,7 +63,6 @@ public class CommentService {
                 .commentContent(request.getCommentContent())
                 .build();
         commentRepository.save(comment);
-        alarmService.createAlarm(Alarm.ofComment(post.getMember().getMemberId(), memberId, comment.getCommentId(), postId));
         return CommentCreateResponse.of(comment,member);
     }
     //댓글 삭제

--- a/src/main/java/com/instagram/backend/domain/message/service/MessageService.java
+++ b/src/main/java/com/instagram/backend/domain/message/service/MessageService.java
@@ -28,6 +28,7 @@ import com.instagram.backend.global.dto.CursorPageResponse;
 import com.instagram.backend.global.exception.BusinessException;
 import com.instagram.backend.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -62,6 +63,7 @@ import java.util.Set;
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
+@Slf4j
 public class MessageService {
 
     // 목록 조회 limit 기본값/최대값 (명세서: 기본 30)
@@ -191,9 +193,13 @@ public class MessageService {
         List<ChatRoomMember> members = chatRoomMemberRepository.findByChatRoomId(roomId);
         for (ChatRoomMember member : members) {
             if (!member.getMemberId().equals(myMemberId)) {
-                alarmService.createAlarm(
-                        Alarm.ofMessage(member.getMemberId(), myMemberId,
-                                savedMessage.getMessageId(), roomId));
+                try {
+                    alarmService.createAlarm(
+                            Alarm.ofMessage(member.getMemberId(), myMemberId,
+                                    savedMessage.getMessageId(), roomId));
+                } catch (Exception e) {
+                    log.warn("MESSAGE 알람 생성 실패 (memberId={}): {}", member.getMemberId(), e.getMessage());
+                }
             }
         }
 

--- a/src/main/java/com/instagram/backend/domain/message/service/MessageService.java
+++ b/src/main/java/com/instagram/backend/domain/message/service/MessageService.java
@@ -1,5 +1,7 @@
 package com.instagram.backend.domain.message.service;
 
+import com.instagram.backend.domain.alarm.entity.Alarm;
+import com.instagram.backend.domain.alarm.service.AlarmService;
 import com.instagram.backend.domain.chat.entity.ChatRoomMember;
 import com.instagram.backend.domain.chat.repository.ChatRoomMemberRepository;
 import com.instagram.backend.domain.chat.repository.ChatRoomRepository;
@@ -78,6 +80,7 @@ public class MessageService {
     private final MemberRepository memberRepository;
     private final PostRepository postRepository;
     private final StoryRepository storyRepository;
+    private final AlarmService alarmService;
 
     /*
       메시지 전송 — POST /api/chats/{roomId}/messages
@@ -183,6 +186,16 @@ public class MessageService {
         //    — findById(Long)은 탈퇴 계정까지 노출하므로 프로젝트 전반의 isDeletedFalse 패턴 사용
         Member sender = memberRepository.findByMemberIdAndIsDeletedFalse(myMemberId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+
+        // 8) 채팅방 참여자(발신자 제외)에게 MESSAGE 알람 전송
+        List<ChatRoomMember> members = chatRoomMemberRepository.findByChatRoomId(roomId);
+        for (ChatRoomMember member : members) {
+            if (!member.getMemberId().equals(myMemberId)) {
+                alarmService.createAlarm(
+                        Alarm.ofMessage(member.getMemberId(), myMemberId,
+                                savedMessage.getMessageId(), roomId));
+            }
+        }
 
         return buildSendResponse(savedMessage, sender, dtype, request, sharedPost, sharedStory);
     }

--- a/src/main/java/com/instagram/backend/domain/story/service/StoryService.java
+++ b/src/main/java/com/instagram/backend/domain/story/service/StoryService.java
@@ -13,6 +13,7 @@ import com.instagram.backend.domain.story.repository.StoryVisitorRepository;
 import com.instagram.backend.global.exception.BusinessException;
 import com.instagram.backend.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,6 +27,7 @@ import java.util.stream.Collectors;
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
+@Slf4j
 public class StoryService {
 
     private static final Set<String> ALLOWED_IMAGE_TYPES = Set.of(
@@ -77,6 +79,9 @@ public class StoryService {
                     // storyId는 findStory()에서, memberId는 JWT 인증에서 검증된 값이므로
                     // 이 시점의 DataIntegrityViolationException은 레이스 컨디션으로 인한
                     // UNIQUE 위반(story_id, member_id)만 해당 — 안전하게 무시
+                } catch (Exception e) {
+                    log.warn("STORY_VIEW 알람 생성 실패 (storyId={}): {}", storyId, e.getMessage());
+                    // StoryVisitor는 정상 저장됨 — 알람 실패만 무시
                 }
             }
         }

--- a/src/main/java/com/instagram/backend/domain/story/service/StoryService.java
+++ b/src/main/java/com/instagram/backend/domain/story/service/StoryService.java
@@ -1,5 +1,7 @@
 package com.instagram.backend.domain.story.service;
 
+import com.instagram.backend.domain.alarm.entity.Alarm;
+import com.instagram.backend.domain.alarm.service.AlarmService;
 import com.instagram.backend.domain.follow.repository.FollowRepository;
 import com.instagram.backend.domain.member.entity.Member;
 import com.instagram.backend.domain.member.repository.MemberRepository;
@@ -34,6 +36,7 @@ public class StoryService {
     private final StoryVisitorRepository storyVisitorRepository;
     private final FollowRepository followRepository;
     private final MemberRepository memberRepository;
+    private final AlarmService alarmService;
 
     @Transactional
     public StoryCreateResponse createStory(Long memberId, StoryCreateRequest request) {
@@ -69,6 +72,7 @@ public class StoryService {
                             .memberId(memberId)
                             .build();
                     storyVisitorRepository.save(visitor);
+                    alarmService.createAlarm(Alarm.ofStoryView(story.getMemberId(), memberId, storyId));
                 } catch (DataIntegrityViolationException ignored) {
                     // storyId는 findStory()에서, memberId는 JWT 인증에서 검증된 값이므로
                     // 이 시점의 DataIntegrityViolationException은 레이스 컨디션으로 인한


### PR DESCRIPTION
## Summary
- `getUnreadCount` DB COUNT 쿼리를 Redis 카운터(`alarm:unread:{memberId}`)로 대체
- STORY_VIEW / MESSAGE 알람 타입 추가
- COMMENT 알람 제거 (향후 MENTION으로 재추가 예정)

## Changes
- `AlarmType` — STORY_VIEW, MESSAGE enum 추가
- `Alarm` — ofStoryView(), ofMessage() 팩토리 메서드 추가
- `AlarmService` — Redis INCR/DECR/fallback 연동 (장애 시 DB fallback 보장)
- `ChatRoomMemberRepository` — findByChatRoomId(Long) 추가
- `StoryService` — getStory()에 STORY_VIEW 알람 연동
- `MessageService` — sendMessage()에 MESSAGE 알람 연동 (DM/그룹 모두)
- `CommentService` — COMMENT 알람 및 AlarmService 의존성 제거

Closes #61